### PR TITLE
Fix Note about supportedEntryTypes

### DIFF
--- a/painttiming.bs
+++ b/painttiming.bs
@@ -83,7 +83,7 @@ The {{PerformancePaintTiming}} interface {#sec-PerformancePaintTiming}
 * The {{PerformanceEntry/startTime}} attribute must return a {{DOMHighResTimeStamp}} of when the paint occured.
 * The {{PerformanceEntry/duration}} attribute must return 0.
 
-NOTE: A user agent implementing {{PerformancePaintTiming}} would need to include <code>"first-paint"</code> and <code>"first-contentful-paint"</code> in {{PerformanceObserver/supportedEntryTypes}} for {{Window}} contexts.
+NOTE: A user agent implementing {{PerformancePaintTiming}} would need to include <code>"paint"</code> in {{PerformanceObserver/supportedEntryTypes}} for {{Window}} contexts.
 This allows developers to detect support for paint timing.
 
 Processing model {#sec-processing-model}


### PR DESCRIPTION
Fixes https://github.com/w3c/paint-timing/issues/48. The type introduced in this spec is just 'paint'.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/paint-timing/pull/49.html" title="Last updated on Feb 27, 2020, 7:44 PM UTC (4bcae73)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/paint-timing/49/e58ecf8...4bcae73.html" title="Last updated on Feb 27, 2020, 7:44 PM UTC (4bcae73)">Diff</a>