### PR TITLE
Editorial fixes

### DIFF
--- a/painttiming.bs
+++ b/painttiming.bs
@@ -64,9 +64,9 @@ Formally, we consider the user agent to have "rendered" a document when it has p
 
 <dfn export>First Contentful Paint</dfn> entry contains a {{DOMHighResTimeStamp}} reporting the time when the user agent first rendered any text, image (including background images), non-white canvas or SVG. This excludes any content of iframes, but includes text with pending webfonts. This is the first time users could start consuming page content.
 
-Whenever a user agent preemptively paints content outside of the viewport, those paints MUST be considered for <a>First Paint</a> and <a>First Contentful Paint</a>.
+Whenever a user agent preemptively paints content outside of the viewport, those paints must be considered for [=First Paint=] and [=First Contentful Paint=].
 
-    NOTE: a user agent has freedom to choose their own strategy for painting. Such strategy could even be to never paint content that is outside of the viewport. Therefore, different user agents can have different behaviors for <a>First Paint</a> and <a>First Contentful Paint</a> in edge cases where the only content occurs outside of the viewport.
+    NOTE: a user agent has freedom to choose their own strategy for painting. Such strategy could even be to never paint content that is outside of the viewport. Therefore, different user agents can have different behaviors for [=First Paint=] and [=First Contentful Paint=] in edge cases where the only content occurs outside of the viewport.
 
 The {{PerformancePaintTiming}} interface {#sec-PerformancePaintTiming}
 =======================================
@@ -78,12 +78,12 @@ The {{PerformancePaintTiming}} interface {#sec-PerformancePaintTiming}
 
 {{PerformancePaintTiming}} extends the following attributes of {{PerformanceEntry}} interface:
 
-* The {{PerformanceEntry/name}} attribute must return a {{DOMString}} for minimal frame attribution. Possible values of name are:
+* The {{PerformanceEntry/name}} attribute's getter must return a {{DOMString}} for minimal frame attribution. Possible values of name are:
     * <code>"first-paint"</code>: for [=First Paint=]
     * <code>"first-contentful-paint"</code>: for [=First Contentful Paint=]
-* The {{PerformanceEntry/entryType}} attribute must return <code>"paint"</code>.
-* The {{PerformanceEntry/startTime}} attribute must return a {{DOMHighResTimeStamp}} of when the paint occured.
-* The {{PerformanceEntry/duration}} attribute must return 0.
+* The {{PerformanceEntry/entryType}} attribute's getter must return <code>"paint"</code>.
+* The {{PerformanceEntry/startTime}} attribute's getter must return a {{DOMHighResTimeStamp}} of when the paint occured.
+* The {{PerformanceEntry/duration}} attribute's getter must return 0.
 
 NOTE: A user agent implementing {{PerformancePaintTiming}} would need to include <code>"paint"</code> in {{PerformanceObserver/supportedEntryTypes}} for {{Window}} contexts.
 This allows developers to detect support for paint timing.
@@ -100,17 +100,17 @@ Reporting paint timing {#sec-reporting-paint-timing}
     Perform the following steps:
 
     1. Let |paintTimestamp| be the input timestamp.
-    1. If this instance of [=update the rendering=] is the <a>first paint</a>, then record the timestamp as |paintTimestamp| and invoke the [[#report-paint-timing]] algorithm with two arguments: <code>"first-paint"</code> and |paintTimestamp|.
+    1. If this instance of [=update the rendering=] is the [=First Paint=], then record the timestamp as |paintTimestamp| and invoke the [[#report-paint-timing]] algorithm with two arguments: <code>"first-paint"</code> and |paintTimestamp|.
 
-        NOTE: First paint excludes the default background paint, but includes non-default background paint.
+        NOTE: [=First Paint=] excludes the default background paint, but includes non-default background paint.
 
-    1. Otherwise, if this instance of [=update the rendering=] is the <a>first contentful paint</a>, then record the timestamp as |paintTimestamp| and invoke the [[#report-paint-timing]] algorithm with two arguments: <code>"first-contentful-paint"</code> and |paintTimestamp|.
+    1. Otherwise, if this instance of [=update the rendering=] is the [=First Contentful Paint</a>, then record the timestamp as |paintTimestamp| and invoke the [[#report-paint-timing]] algorithm with two arguments: <code>"first-contentful-paint"</code> and |paintTimestamp|.
 
         NOTE: This paint must include text, image (including background images), non-white canvas or SVG.
 
     1. Otherwise, do nothing and return.
 
-        NOTE: A parent frame should not be aware of the paint events from its child iframes, and vice versa. This means that a frame that contains just iframes will have first paint (due to the enclosing boxes of the iframes) but no first contentful paint.
+        NOTE: A parent frame should not be aware of the paint events from its child iframes, and vice versa. This means that a frame that contains just iframes will have [=First Paint=] (due to the enclosing boxes of the iframes) but no [=First Contentful Paint=].
 </div>
 
 <h4 dfn>Report paint timing</h4>

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -8,7 +8,7 @@ TR: https://www.w3.org/TR/paint-timing/
 Status: ED
 Editor: Shubhie Panicker, Google https://google.com, panicker@google.com
 Repository: w3c/paint-timing
-Abstract: This document defines an API that can be used to capture a series of key moments (First Paint, First Contentful Paint) during pageload which developers care about.
+Abstract: This document defines an API that can be used to capture a series of key moments (first paint, first contentful paint) during pageload which developers care about.
 Default Highlight: js
 </pre>
 
@@ -31,7 +31,7 @@ Introduction {#intro}
 =====================
 Load is not a single moment in time — it's an experience that no one metric can fully capture. There are multiple moments during the load experience that can affect whether a user perceives it as "fast" or "slow".
 
-First Paint (FP) is the first of these key moments, followed by First Contentful Paint (FCP). These metrics mark the points, immediately after navigation, when the browser renders pixels to the screen. This is important to the user because it answers the question: is it happening?
+First paint (FP) is the first of these key moments, followed by first contentful paint (FCP). These metrics mark the points, immediately after navigation, when the browser renders pixels to the screen. This is important to the user because it answers the question: is it happening?
 
 The primary difference between the two metrics is FP marks the point when the browser renders anything that is visually different from what was on the screen prior to navigation. By contrast, FCP is the point when the browser renders the first bit of content from the DOM, which may be text, an image, SVG, or even a canvas element.
 
@@ -60,13 +60,13 @@ Formally, we consider the user agent to have "rendered" a document when it has p
 
     NOTE: The rendering pipeline is very complex, and the timestamp should be the latest timestamp the user agent is able to note in this pipeline (best effort). Typically the time at which the frame is submitted to the OS for display is recommended for this API.
 
-<dfn export>First Paint</dfn> entry contains a {{DOMHighResTimeStamp}} reporting the time when the user agent first rendered after navigation. This excludes the default background paint, but includes non-default background paint and the enclosing box of an iframe. This is the first key moment developers care about in page load – when the user agent has started to render the page.
+<dfn export>First paint</dfn> entry contains a {{DOMHighResTimeStamp}} reporting the time when the user agent first rendered after navigation. This excludes the default background paint, but includes non-default background paint and the enclosing box of an iframe. This is the first key moment developers care about in page load – when the user agent has started to render the page.
 
-<dfn export>First Contentful Paint</dfn> entry contains a {{DOMHighResTimeStamp}} reporting the time when the user agent first rendered any text, image (including background images), non-white canvas or SVG. This excludes any content of iframes, but includes text with pending webfonts. This is the first time users could start consuming page content.
+<dfn export>First contentful paint</dfn> entry contains a {{DOMHighResTimeStamp}} reporting the time when the user agent first rendered any text, image (including background images), non-white canvas or SVG. This excludes any content of iframes, but includes text with pending webfonts. This is the first time users could start consuming page content.
 
-Whenever a user agent preemptively paints content outside of the viewport, those paints must be considered for [=First Paint=] and [=First Contentful Paint=].
+Whenever a user agent preemptively paints content outside of the viewport, those paints must be considered for [=first paint=] and [=first contentful paint=].
 
-    NOTE: a user agent has freedom to choose their own strategy for painting. Such strategy could even be to never paint content that is outside of the viewport. Therefore, different user agents can have different behaviors for [=First Paint=] and [=First Contentful Paint=] in edge cases where the only content occurs outside of the viewport.
+    NOTE: a user agent has freedom to choose their own strategy for painting. Such strategy could even be to never paint content that is outside of the viewport. Therefore, different user agents can have different behaviors for [=first paint=] and [=first contentful paint=] in edge cases where the only content occurs outside of the viewport.
 
 The {{PerformancePaintTiming}} interface {#sec-PerformancePaintTiming}
 =======================================
@@ -79,8 +79,8 @@ The {{PerformancePaintTiming}} interface {#sec-PerformancePaintTiming}
 {{PerformancePaintTiming}} extends the following attributes of {{PerformanceEntry}} interface:
 
 * The {{PerformanceEntry/name}} attribute's getter must return a {{DOMString}} for minimal frame attribution. Possible values of name are:
-    * <code>"first-paint"</code>: for [=First Paint=]
-    * <code>"first-contentful-paint"</code>: for [=First Contentful Paint=]
+    * <code>"first-paint"</code>: for [=first paint=]
+    * <code>"first-contentful-paint"</code>: for [=first contentful paint=]
 * The {{PerformanceEntry/entryType}} attribute's getter must return <code>"paint"</code>.
 * The {{PerformanceEntry/startTime}} attribute's getter must return a {{DOMHighResTimeStamp}} of when the paint occured.
 * The {{PerformanceEntry/duration}} attribute's getter must return 0.
@@ -100,17 +100,17 @@ Reporting paint timing {#sec-reporting-paint-timing}
     Perform the following steps:
 
     1. Let |paintTimestamp| be the input timestamp.
-    1. If this instance of [=update the rendering=] is the [=First Paint=], then record the timestamp as |paintTimestamp| and invoke the [[#report-paint-timing]] algorithm with two arguments: <code>"first-paint"</code> and |paintTimestamp|.
+    1. If this instance of [=update the rendering=] is the [=first paint=], then record the timestamp as |paintTimestamp| and invoke the [[#report-paint-timing]] algorithm with two arguments: <code>"first-paint"</code> and |paintTimestamp|.
 
-        NOTE: [=First Paint=] excludes the default background paint, but includes non-default background paint.
+        NOTE: [=First paint=] excludes the default background paint, but includes non-default background paint.
 
-    1. Otherwise, if this instance of [=update the rendering=] is the [=First Contentful Paint</a>, then record the timestamp as |paintTimestamp| and invoke the [[#report-paint-timing]] algorithm with two arguments: <code>"first-contentful-paint"</code> and |paintTimestamp|.
+    1. Otherwise, if this instance of [=update the rendering=] is the [=first contentful paint</a>, then record the timestamp as |paintTimestamp| and invoke the [[#report-paint-timing]] algorithm with two arguments: <code>"first-contentful-paint"</code> and |paintTimestamp|.
 
         NOTE: This paint must include text, image (including background images), non-white canvas or SVG.
 
     1. Otherwise, do nothing and return.
 
-        NOTE: A parent frame should not be aware of the paint events from its child iframes, and vice versa. This means that a frame that contains just iframes will have [=First Paint=] (due to the enclosing boxes of the iframes) but no [=First Contentful Paint=].
+        NOTE: A parent frame should not be aware of the paint events from its child iframes, and vice versa. This means that a frame that contains just iframes will have [=first paint=] (due to the enclosing boxes of the iframes) but no [=first contentful paint=].
 </div>
 
 <h4 dfn>Report paint timing</h4>


### PR DESCRIPTION
Fixes https://github.com/w3c/paint-timing/issues/12

* Prefer bikeshed syntax
* Use consistent capitalization
* "Attribute must return" should instead be "attribute's getter must return".


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/paint-timing/pull/64.html" title="Last updated on Mar 6, 2020, 7:22 PM UTC (291fc5e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/paint-timing/64/a3113c3...291fc5e.html" title="Last updated on Mar 6, 2020, 7:22 PM UTC (291fc5e)">Diff</a>