### PR TITLE
Add link to viewport

### DIFF
--- a/painttiming.bs
+++ b/painttiming.bs
@@ -25,6 +25,8 @@ urlPrefix: https://www.w3.org/TR/performance-timeline-2/; spec: PERFORMANCE-TIME
         text: supportedEntryTypes; url: #supportedentrytypes-attribute
 urlPrefix: https://www.w3.org/TR/hr-time-2/#idl-def-domhighrestimestamp; spec: HR-TIME-2;
     type: typedef; text: DOMHighResTimeStamp
+urlPrefix: https://www.w3.org/TR/CSS2/visuren.html; spec: CSS-2;
+    type: dfn; url: #viewport; text: viewport
 </pre>
 
 Introduction {#intro}
@@ -64,7 +66,7 @@ Formally, we consider the user agent to have "rendered" a document when it has p
 
 <dfn export>First Contentful Paint</dfn> entry contains a {{DOMHighResTimeStamp}} reporting the time when the user agent first rendered any text, image (including background images), non-white canvas or SVG. This excludes any content of iframes, but includes text with pending webfonts. This is the first time users could start consuming page content.
 
-Whenever a user agent preemptively paints content outside of the viewport, those paints MUST be considered for <a>First Paint</a> and <a>First Contentful Paint</a>.
+Whenever a user agent preemptively paints content outside of the [=viewport=], those paints MUST be considered for <a>First Paint</a> and <a>First Contentful Paint</a>.
 
     NOTE: a user agent has freedom to choose their own strategy for painting. Such strategy could even be to never paint content that is outside of the viewport. Therefore, different user agents can have different behaviors for <a>First Paint</a> and <a>First Contentful Paint</a> in edge cases where the only content occurs outside of the viewport.
 


### PR DESCRIPTION
A request was made to add a link to the viewport.
Fixes https://github.com/w3c/paint-timing/issues/58


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/paint-timing/pull/65.html" title="Last updated on Mar 6, 2020, 7:00 PM UTC (9270454)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/paint-timing/65/cb5e822...9270454.html" title="Last updated on Mar 6, 2020, 7:00 PM UTC (9270454)">Diff</a>