### PR TITLE
Clarify what 'contentful' means

### DIFF
--- a/painttiming.bs
+++ b/painttiming.bs
@@ -27,6 +27,10 @@ urlPrefix: https://www.w3.org/TR/hr-time-2/#idl-def-domhighrestimestamp; spec: H
     type: typedef; text: DOMHighResTimeStamp
 urlPrefix: https://www.w3.org/TR/CSS2/visuren.html; spec: CSS-2;
     type: dfn; url: #viewport; text: viewport
+urlPrefix: https://www.w3.org/TR/CSS22/visufx.html; spec: CSS-2;
+    type: dfn; url: #propdef-visibility; text: visibility;
+urlPrefix: https://www.w3.org/TR/css-color-3; spec: CSS-COLOR-3;
+    type: dfn; url: #opacity; text: opacity;
 urlPrefix: https://www.w3.org/TR/cssom-view/; spec: CSSOM-VIEW-1;
     type: dfn; text: getBoundingClientRect; url: #dom-element-getboundingclientrect
 urlPrefix: https://dom.spec.whatwg.org/; spec: DOM
@@ -45,7 +49,8 @@ urlPrefix: https://html.spec.whatwg.org/
     type: dfn; text: canvas; url: #the-canvas-element;
     type: dfn; text: context mode; url: #concept-canvas-context-mode;
     type: dfn; text: replaced image; url: #images-3;
-
+urlPrefix: https://w3c.github.io/IntersectionObserver/
+    type: dfn; text: Intersection rect algorithm; url: #calculate-intersection-rect-algo
 </pre>
 
 Introduction {#intro}
@@ -95,9 +100,17 @@ Formally, we consider the user agent to have "rendered" a document when it has p
 * The element is a [=canvas=] with its [=context mode=] set to any value other than <code>none</code>.
 * The element is an [=svg element with rendered descendants=].
 
+<dfn export>Paintable</dfn>: An element counts as paintable when all of the following apply:
+* The element intersects with the document, as defined by [=Intersection rect algorithm=]. 
+
+    NOTE: This covers the cases where the element is transformed to zero size, or is positioned in negative coordinates,
+
+* The element's [=visibility=] is visible.
+* The element's [=opacity=] is greater than 0.
+
 <dfn export>First paint</dfn> entry contains a {{DOMHighResTimeStamp}} reporting the time when the user agent first rendered after navigation. This excludes the default background paint, but includes non-default background paint and the enclosing box of an iframe. This is the first key moment developers care about in page load – when the user agent has started to render the page.
 
-<dfn export>First contentful paint</dfn> entry contains a {{DOMHighResTimeStamp}} reporting the time when the user agent first rendered an element or part of an element which counts as [=contentful=], and has a non-empty bounding rect, as returned by [=getBoundingClientRect=].
+<dfn export>First contentful paint</dfn> entry contains a {{DOMHighResTimeStamp}} reporting the time when the user agent first rendered an element or part of an element which counts as [=contentful=] and [=paintable=].
 
 Whenever a user agent preemptively paints content outside of the [=viewport=], those paints must be considered for [=first paint=] and [=first contentful paint=].
 
@@ -141,7 +154,7 @@ Reporting paint timing {#sec-reporting-paint-timing}
 
     1. If this instance of [=update the rendering=] is the [=first contentful paint=] of |document|, then invoke the [[#report-paint-timing]] algorithm with |document|, <code>"first-contentful-paint"</code>, and |paintTimestamp| as arguments.
 
-        NOTE: This paint must include [=contentful=] elemenets with a non empty bounding rect as defined in [=getBoundingClientRect=].
+        NOTE: This paint must include elemenets that are both [=contentful=] and [=paintable=].
 
         NOTE: A parent frame should not be aware of the paint events from its child iframes, and vice versa. This means that a frame that contains just iframes will have [=first paint=] (due to the enclosing boxes of the iframes) but no [=first contentful paint=].
 </div>

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -37,6 +37,7 @@ urlPrefix: https://www.w3.org/TR/SVG2/render.html; spec: CR-SVG2
     type: dfn; url: #Rendered-vs-NonRendered; text: svg element with rendered descendants;
 urlPrefix: https://www.w3.org/TR/css-backgrounds-3/; spec: CSS-BACKGROUNDS-3;
     type: dfn; text: background-image; url: #propdef-background-image;
+    type: dfn; text: background-size; url: #background-size;
 urlPrefix: https://html.spec.whatwg.org/multipage/canvas.html
     type: dfn; text: canvas;
     type: dfn; text: context mode; url: #concept-canvas-context-mode;
@@ -52,6 +53,7 @@ urlPrefix: https://drafts.csswg.org/css-pseudo-4
     type: dfn; text: generated content pseudo-element; url: #generated-content;
 urlPrefix: https://www.w3.org/TR/cssom-view
     type: dfn; text: getBoundingClientRect; url: #dom-element-getboundingclientrect;
+    type: dfn; text: scrolling area; url: #scrolling-area;
 </pre>
 
 Introduction {#intro}
@@ -97,11 +99,12 @@ Formally, we consider the user agent to have "rendered" a document when it has p
 A [=generated content pseudo-element=] is a <dfn>paintable pseudo-element</dfn> when all of the following apply:
 * The pseudo-element's [=used=] [=visibility=] is <code>visible</code>.
 * The pseudo-element's [=used=] [=opacity=] is greater than zero.
+* The pseudo-element generates a non-empty [=box=].
 
 An [=element=] is <dfn export>contentful</dfn> when one or more of the following apply:
 * The element has a [=text node=] child, with at least one character, excluding [=document white space characters=].
 * The element is a [=replaced element=] representing a [=loaded=] image.
-* The element's [=used=] style contains a [=loaded=] [=background-image=].
+* The element has a [=loaded=] [=background-image=], and its [=used=] [=background-size=] has non-zero width and height values.
 
     NOTE: a gradient is not considered a loaded background image, and thus would not make an element count as contentful.
 
@@ -120,7 +123,7 @@ An [=element=] is <dfn>paintable</dfn> when all of the following apply:
     NOTE: there could be cases where a <code>paintable</code> [=element=] would not be visible to the user, for example in the case of text that has the same color as its background.
     Those elements would still considered as paintable for the purpose of computing [=first contentful paint=].    
 
-* The element's [=paintable bounding rect=] has positive right, bottom, width and height values. 
+* The element's [=paintable bounding rect=] intersects with the [=scrolling area=] of the [=document=]. 
     
     NOTE: This covers the cases where the element is scaled to zero size, has <code>display: none</code>, or <code>display: contents</code> where the contents resolve to an empty rect.
 

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -41,13 +41,13 @@ urlPrefix: https://html.spec.whatwg.org/multipage/canvas.html
     type: dfn; text: canvas;
     type: dfn; text: context mode; url: #concept-canvas-context-mode;
 urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html
-    type: dfn; text: replaced image; url: #images-3;
+    type: dfn; text: replaced element; url: #replaced-elements;
 urlPrefix: https://w3c.github.io/IntersectionObserver/
     type: dfn; text: Intersection rect algorithm; url: #calculate-intersection-rect-algo
 urlPrefix: https://drafts.csswg.org/css-cascade-4/
-    type: dfn; text: computed; url: #computed-value;
+    type: dfn; text: used; url: #used;
 urlPrefix: https://html.spec.whatwg.org/multipage/dom.html
-    type: dfn; text: document-sourced element; url: #element;
+    type: dfn; text: element; url: #element;
 urlPrefix: https://drafts.csswg.org/css-pseudo-4
     type: dfn; text: generated content pseudo-element; url: #generated-content;
 urlPrefix: https://www.w3.org/TR/cssom-view
@@ -94,34 +94,39 @@ Formally, we consider the user agent to have "rendered" a document when it has p
 
     NOTE: The rendering pipeline is very complex, and the timestamp should be the latest timestamp the user agent is able to note in this pipeline (best effort). Typically the time at which the frame is submitted to the OS for display is recommended for this API.
 
-<dfn>Element or pseudo-element</dfn>: A [=document-sourced element=] or a [=generated content pseudo-element=].
-<dfn>Contentful</dfn>: An [=element or pseudo-element=] counts as contentful when one or more of the following apply:
+<dfn>Contentful</dfn>: An [=element=] counts as contentful when one or more of the following apply:
 * The element has a [=text node=] child, with at least one character, excluding [=document white space characters=].
-* The element is a [=replaced image=] representing a [=loaded=] image.
-* The element's [=computed=] style contains a [=loaded=] [=background-image=].
+* The element is a [=replaced element=] representing a [=loaded=] image.
+* The element's [=used=] style contains a [=loaded=] [=background-image=].
 * The element is a [=canvas=] with its [=context mode=] set to any value other than <code>none</code>.
 * The element is an [=svg element with rendered descendants=].
-* The element's [=computed=] style contains a [=contentful=] and [=paintable=] [=generated content pseudo-element=].
+* The element is an [=originating element=] for a [=paintable pseudo-element=] that represents a [=loaded=] image or text with at least one character excluding [=document white space characters=].
 
-<dfn>Paintable</dfn>: As a general rule, an [=element or pseudo-element=] is paintable if it is within the viewport, or can potentially be in the viewport as a result of scrolling.
-An [=element or pseudo-element=] counts as paintable when all of the following apply:
-* The element's [=computed=] [=visibility=] is <code>visible</code>.
-* The element and all of its ancestors have positive [=computed=] [=opacity=].
+<dfn>Paintable</dfn>: An [=element=] counts as paintable when all of the following apply:
+* The element's [=used=] [=visibility=] is <code>visible</code>.
+* The element and all of its ancestors' [=used=] [=opacity=] is greater than zero.
 
-    NOTE: there could be cases where a <code>paintable</code> [=element or pseudo-element=] would not be visible to the user, for example in the case of text that has the same color as its background.
+    NOTE: there could be cases where a <code>paintable</code> [=element=] would not be visible to the user, for example in the case of text that has the same color as its background.
     Those elements would still considered as paintable for the purpose of computing [=first contentful paint=].    
 
 * The element's [=paintable bounding rect=] has positive right, bottom, width and height values. 
     
     NOTE: This covers the cases where the element is scaled to zero size, has <code>display: none</code>, or <code>display: contents</code> where the contents resolve to an empty rect.
 
-<dfn>Paintable Bounding Rect</dfn>: The paintable bounding rect is the element's bounding rect, which would be the result of running the [=getBoundingClientRect=] algorithm on the [=element or pseudo-element=], clipped by ancestors with <code>overflow: clip</code>.
+    NOTE: As a general rule, an [=element=] is paintable if it is within the viewport, or can potentially be in the viewport as a result of scrolling or zooming.
 
-    NOTE: elements contained by boxes with <code>overflow: scroll</code> or <code>overflow: hidden</code> don't have their [=paintable bounding rect=] clipped, as in both cases the [=element or pseudo-element=] can become visible by scrolling.
+<dfn>Paintable pseudo-element</dfn>: A [=generated content pseudo-element=] counts as paintable when all of the following apply:
+* The pseudo-element's [=used=] [=visibility=] is <code>visible</code>.
+* The pseudo-element's [=used=] [=opacity=] is greater than zero.
+* The pseudo-element generates a non-empty box.
+
+<dfn>Paintable Bounding Rect</dfn>: The paintable bounding rect is the [=element=]'s bounding rect, which would be the result of running the [=getBoundingClientRect=] algorithm on the [=element=], clipped by ancestors with <code>overflow: clip</code>.
+
+    NOTE: elements contained by boxes with <code>overflow: scroll</code> or <code>overflow: hidden</code> don't have their [=paintable bounding rect=] clipped, as in both cases the [=element=] can become visible by scrolling.
 
 <dfn export>First paint</dfn> entry contains a {{DOMHighResTimeStamp}} reporting the time when the user agent first rendered after navigation. This excludes the default background paint, but includes non-default background paint and the enclosing box of an iframe. This is the first key moment developers care about in page load – when the user agent has started to render the page.
 
-<dfn export>First contentful paint</dfn> entry contains a {{DOMHighResTimeStamp}} reporting the time when the user agent first rendered a [=document=] which includes at least one [=element or pseudo-element=] that is both [=contentful=] and [=paintable=].
+<dfn export>First contentful paint</dfn> entry contains a {{DOMHighResTimeStamp}} reporting the time when the user agent first rendered a [=document=] which includes at least one [=element=] that is both [=contentful=] and [=paintable=].
 
 Whenever a user agent preemptively paints content outside of the [=viewport=], those paints must be considered for [=first paint=] and [=first contentful paint=].
 

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -37,8 +37,6 @@ urlPrefix: https://www.w3.org/TR/SVG2/render.html; spec: CR-SVG2
     type: dfn; url: #Rendered-vs-NonRendered; text: svg element with rendered descendants;
 urlPrefix: https://www.w3.org/TR/css-backgrounds-3/; spec: CSS-BACKGROUNDS-3;
     type: dfn; text: background-image; url: #propdef-background-image;
-urlPrefix: https://www.w3.org/TR/css-masking-1/; spec: CSS-MASKING-1;
-    type: dfn; text: mask-image; url: #the-mask-image;
 urlPrefix: https://html.spec.whatwg.org/multipage/canvas.html
     type: dfn; text: canvas;
     type: dfn; text: context mode; url: #concept-canvas-context-mode;
@@ -49,11 +47,11 @@ urlPrefix: https://w3c.github.io/IntersectionObserver/
 urlPrefix: https://drafts.csswg.org/css-cascade-4/
     type: dfn; text: computed; url: #computed-value;
 urlPrefix: https://html.spec.whatwg.org/multipage/dom.html
-    type: dfn; text: element; url: #element;
+    type: dfn; text: document-sourced element; url: #element;
 urlPrefix: https://drafts.csswg.org/css-pseudo-4
     type: dfn; text: generated content pseudo-element; url: #generated-content;
 urlPrefix: https://www.w3.org/TR/cssom-view
-    type: dfn; text: getBoundingClientRect; url: #getBoundingClientRect;
+    type: dfn; text: getBoundingClientRect; url: #dom-element-getboundingclientrect;
 </pre>
 
 Introduction {#intro}
@@ -96,7 +94,8 @@ Formally, we consider the user agent to have "rendered" a document when it has p
 
     NOTE: The rendering pipeline is very complex, and the timestamp should be the latest timestamp the user agent is able to note in this pipeline (best effort). Typically the time at which the frame is submitted to the OS for display is recommended for this API.
 
-<dfn>Contentful</dfn>: An [=element=] or a [=pseudo-element=] counts as contentful when one or more of the following apply:
+<dfn>Element or pseudo-element</dfn>: A [=document-sourced element=] or a [=generated content pseudo-element=].
+<dfn>Contentful</dfn>: An [=element or pseudo-element=] counts as contentful when one or more of the following apply:
 * The element has a [=text node=] child, with at least one character, excluding [=document white space characters=].
 * The element is a [=replaced image=] representing a [=loaded=] image.
 * The element's [=computed=] style contains a [=loaded=] [=background-image=].
@@ -104,20 +103,25 @@ Formally, we consider the user agent to have "rendered" a document when it has p
 * The element is an [=svg element with rendered descendants=].
 * The element's [=computed=] style contains a [=contentful=] and [=paintable=] [=generated content pseudo-element=].
 
-<dfn>Paintable</dfn>: An [=element=] or a [=generated content pseudo-element=] counts as paintable when all of the following apply:
+<dfn>Paintable</dfn>: As a general rule, an [=element or pseudo-element=] is paintable if it is within the viewport, or can potentially be in the viewport as a result of scrolling.
+An [=element or pseudo-element=] counts as paintable when all of the following apply:
 * The element's [=computed=] [=visibility=] is <code>visible</code>.
 * The element and all of its ancestors have positive [=computed=] [=opacity=].
 
-    NOTE: there could be cases where a <code>paintable</code> element would not be visible to the user, for example in the case of text that has the same color as its background.
+    NOTE: there could be cases where a <code>paintable</code> [=element or pseudo-element=] would not be visible to the user, for example in the case of text that has the same color as its background.
     Those elements would still considered as paintable for the purpose of computing [=first contentful paint=].    
 
-* The element's bounding rect, as returned by [=getBoundingClientRect=] has positive right, bottom, width and height, after applying clipping as defined in [=Intersection rect algorithm=], but without clipping to the [=viewport=]. 
+* The element's [=paintable bounding rect=] has positive right, bottom, width and height values. 
     
     NOTE: This covers the cases where the element is scaled to zero size, has <code>display: none</code>, or <code>display: contents</code> where the contents resolve to an empty rect.
 
+<dfn>Paintable Bounding Rect</dfn>: The paintable bounding rect is the element's bounding rect, which would be the result of running the [=getBoundingClientRect=] algorithm on the [=element or pseudo-element=], clipped by ancestors with <code>overflow: clip</code>.
+
+    NOTE: elements contained by boxes with <code>overflow: scroll</code> or <code>overflow: hidden</code> don't have their [=paintable bounding rect=] clipped, as in both cases the [=element or pseudo-element=] can become visible by scrolling.
+
 <dfn export>First paint</dfn> entry contains a {{DOMHighResTimeStamp}} reporting the time when the user agent first rendered after navigation. This excludes the default background paint, but includes non-default background paint and the enclosing box of an iframe. This is the first key moment developers care about in page load – when the user agent has started to render the page.
 
-<dfn export>First contentful paint</dfn> entry contains a {{DOMHighResTimeStamp}} reporting the time when the user agent first rendered a [=document=] which includes at least one [=element=] that is both [=contentful=] and [=paintable=].
+<dfn export>First contentful paint</dfn> entry contains a {{DOMHighResTimeStamp}} reporting the time when the user agent first rendered a [=document=] which includes at least one [=element or pseudo-element=] that is both [=contentful=] and [=paintable=].
 
 Whenever a user agent preemptively paints content outside of the [=viewport=], those paints must be considered for [=first paint=] and [=first contentful paint=].
 

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -31,7 +31,7 @@ urlPrefix: https://www.w3.org/TR/CSS22/visufx.html; spec: CSS-2;
     type: dfn; url: #propdef-visibility; text: visibility;
 urlPrefix: https://www.w3.org/TR/css-color-3; spec: CSS-COLOR-3;
     type: dfn; url: #opacity; text: opacity;
-urlPrefix: https://www.w3.org/TR/css-images-3/#url-notation; spec: CSS-IMAGES-3;
+urlPrefix: https://www.w3.org/TR/css-images-3/; spec: CSS-IMAGES-3;
     type: dfn; text: loaded; url: #typedef-image
 urlPrefix: https://www.w3.org/TR/SVG2/render.html; spec: CR-SVG2
     type: dfn; url: #Rendered-vs-NonRendered; text: svg element with rendered descendants;

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -31,26 +31,23 @@ urlPrefix: https://www.w3.org/TR/CSS22/visufx.html; spec: CSS-2;
     type: dfn; url: #propdef-visibility; text: visibility;
 urlPrefix: https://www.w3.org/TR/css-color-3; spec: CSS-COLOR-3;
     type: dfn; url: #opacity; text: opacity;
-urlPrefix: https://www.w3.org/TR/cssom-view/; spec: CSSOM-VIEW-1;
-    type: dfn; text: getBoundingClientRect; url: #dom-element-getboundingclientrect
-urlPrefix: https://dom.spec.whatwg.org/; spec: DOM
-    type: dfn; text: text node; url: #text
 urlPrefix: https://www.w3.org/TR/css-images-3/#url-notation; spec: CSS-IMAGES-3;
     type: dfn; text: loaded; url: #typedef-image
 urlPrefix: https://www.w3.org/TR/SVG2/render.html; spec: CR-SVG2
     type: dfn; url: #Rendered-vs-NonRendered; text: svg element with rendered descendants;
-urlPrefix: https://www.w3.org/TR/css-text-3; spec: CSS-TEXT-3;
-    type: dfn; text: white-space; url: #white-space;
 urlPrefix: https://www.w3.org/TR/css-backgrounds-3/; spec: CSS-BACKGROUNDS-3;
     type: dfn; text: background-image; url: #propdef-background-image;
-urlPrefix: https://www.w3.org/TR/css-backgrounds-3/; spec: CSS-MASKING-1;
+urlPrefix: https://www.w3.org/TR/css-masking-1/; spec: CSS-MASKING-1;
     type: dfn; text: mask-image; url: #the-mask-image;
-urlPrefix: https://html.spec.whatwg.org/
-    type: dfn; text: canvas; url: #the-canvas-element;
+urlPrefix: https://html.spec.whatwg.org/multipage/canvas.html
+    type: dfn; text: canvas;
     type: dfn; text: context mode; url: #concept-canvas-context-mode;
+urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html
     type: dfn; text: replaced image; url: #images-3;
 urlPrefix: https://w3c.github.io/IntersectionObserver/
     type: dfn; text: Intersection rect algorithm; url: #calculate-intersection-rect-algo
+urlPrefix: https://drafts.csswg.org/css-cascade-4/
+    type: dfn; text: computed; url: #computed-value;
 </pre>
 
 Introduction {#intro}
@@ -93,20 +90,21 @@ Formally, we consider the user agent to have "rendered" a document when it has p
 
     NOTE: The rendering pipeline is very complex, and the timestamp should be the latest timestamp the user agent is able to note in this pipeline (best effort). Typically the time at which the frame is submitted to the OS for display is recommended for this API.
 
-<dfn export>Contentful</dfn>: An element counts as contentful when one or more of the following apply:
-* The element contains a [=text node=], with at least one character, excluding [=white-space=].
+<dfn>Contentful</dfn>: An element counts as contentful when one or more of the following apply:
+* The element has a [=text node=] descendant, with at least one character, excluding [=document white space characters=].
 * The element is a [=replaced image=] representing a [=loaded=] image.
 * The element's current style contains a [=loaded=] [=background-image=] or [=mask-image=].
 * The element is a [=canvas=] with its [=context mode=] set to any value other than <code>none</code>.
 * The element is an [=svg element with rendered descendants=].
 
-<dfn export>Paintable</dfn>: An element counts as paintable when all of the following apply:
+<dfn>Paintable</dfn>: An element counts as paintable when all of the following apply:
 * The element intersects with the document, as defined by [=Intersection rect algorithm=]. 
 
     NOTE: This covers the cases where the element is transformed to zero size, or is positioned in negative coordinates,
 
-* The element's [=visibility=] is visible.
-* The element's [=opacity=] is greater than 0.
+* The element's [=computed=] [=visibility=] is <code>visible</code>.
+* The element is not fully transparent, as defined  [=computed=] [=opacity=] is greater than 0.
+* All of the element's ancestors have [=computed=] [=opacity=]
 
 <dfn export>First paint</dfn> entry contains a {{DOMHighResTimeStamp}} reporting the time when the user agent first rendered after navigation. This excludes the default background paint, but includes non-default background paint and the enclosing box of an iframe. This is the first key moment developers care about in page load – when the user agent has started to render the page.
 

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -124,7 +124,7 @@ To compute the <dfn>paintable bounding rect</dfn> of [=element=] |target|, run t
     1. Let |boundingRect| be the result of running the [=getBoundingClientRect=] on |target|.
     1. Let |container| be the [=containing block=] of |target|.
     1. While |container| is not the [=document=]
-        1. If container has <code>overflow: clip</code>, or its [=used=] style a css [=clip-path=] property, update |boundingRect| by applying |container|’s clip.
+        1. If container has <code>overflow: clip</code>, or its [=used=] style has a css [=clip-path=] property, update |boundingRect| by applying |container|’s clip.
         1. Update |container| to be the [=containing block=] of |container|.
     1. Clip |boundingRect| with the [=document=]'s [=scrolling area=].
     1. Return |boundingRect|.

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -102,7 +102,7 @@ An [=element=] is <dfn export>contentful</dfn> when one or more of the following
 * The element is an [=svg element with rendered descendants=].
 * The element is an [=originating element=] for a [=paintable pseudo-element=] that represents a [=loaded=] image or text with at least one character excluding [=document white space characters=].
 
-<dfn>Paintable</dfn>: An [=element=] counts as paintable when all of the following apply:
+An [=element=] is <dfn>paintable</dfn> when all of the following apply:
 * The element's [=used=] [=visibility=] is <code>visible</code>.
 * The element and all of its ancestors' [=used=] [=opacity=] is greater than zero.
 
@@ -115,10 +115,9 @@ An [=element=] is <dfn export>contentful</dfn> when one or more of the following
 
     NOTE: As a general rule, an [=element=] is paintable if it is within the viewport, or can potentially be in the viewport as a result of scrolling or zooming.
 
-<dfn>Paintable pseudo-element</dfn>: A [=generated content pseudo-element=] counts as paintable when all of the following apply:
+A [=generated content pseudo-element=] is a <dfn>paintable pseudo-element</dfn> when all of the following apply:
 * The pseudo-element's [=used=] [=visibility=] is <code>visible</code>.
 * The pseudo-element's [=used=] [=opacity=] is greater than zero.
-* The pseudo-element generates a non-empty box.
 
 <dfn>Paintable Bounding Rect</dfn>: The paintable bounding rect is the [=element=]'s bounding rect, which would be the result of running the [=getBoundingClientRect=] algorithm on the [=element=], clipped by ancestors with <code>overflow: clip</code>.
 

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -122,10 +122,6 @@ An [=element=] |target| is <dfn export>contentful</dfn> when one or more of the 
 
 To compute the <dfn>paintable bounding rect</dfn> of [=element=] |target|, run the following steps:
     1. Let |boundingRect| be the result of running the [=getBoundingClientRect=] on |target|.
-    1. Let |container| be the [=containing block=] of |target|.
-    1. While |container| is not the [=document=]
-        1. If container has <code>overflow: clip</code>, or its [=used=] style has a css [=clip-path=] property, update |boundingRect| by applying |container|’s clip.
-        1. Update |container| to be the [=containing block=] of |container|.
     1. Clip |boundingRect| with the [=document=]'s [=scrolling area=].
     1. Return |boundingRect|.
 
@@ -189,8 +185,6 @@ Reporting paint timing {#sec-reporting-paint-timing}
         NOTE: [=First paint=] excludes the default background paint, but includes non-default background paint.
 
     1. If this instance of [=update the rendering=] is the [=first contentful paint=] of |document|, then invoke the [[#report-paint-timing]] algorithm with |document|, <code>"first-contentful-paint"</code>, and |paintTimestamp| as arguments.
-
-        NOTE: This paint must include elements that are both [=contentful=] and [=paintable=].
 
         NOTE: A parent frame should not be aware of the paint events from its child iframes, and vice versa. This means that a frame that contains just iframes will have [=first paint=] (due to the enclosing boxes of the iframes) but no [=first contentful paint=].
 </div>

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -122,6 +122,7 @@ An [=element=] is <dfn>paintable</dfn> when all of the following apply:
     NOTE: This covers the cases where the element is scaled to zero size, has <code>display: none</code>, or <code>display: contents</code> where the contents resolve to an empty rect.
 
     NOTE: As a general rule, an [=element=] is paintable if it is within the viewport, or can potentially be in the viewport as a result of scrolling or zooming.
+
 <dfn export>First paint</dfn> entry contains a {{DOMHighResTimeStamp}} reporting the time when the user agent first rendered after navigation. This excludes the default background paint, but includes non-default background paint and the enclosing box of an iframe. This is the first key moment developers care about in page load – when the user agent has started to render the page.
 
 <dfn export>First contentful paint</dfn> entry contains a {{DOMHighResTimeStamp}} reporting the time when the user agent first rendered a [=document=] which includes at least one [=element=] that is both [=contentful=] and [=paintable=].

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -152,7 +152,7 @@ Reporting paint timing {#sec-reporting-paint-timing}
 
     1. If this instance of [=update the rendering=] is the [=first contentful paint=] of |document|, then invoke the [[#report-paint-timing]] algorithm with |document|, <code>"first-contentful-paint"</code>, and |paintTimestamp| as arguments.
 
-        NOTE: This paint must include elemenets that are both [=contentful=] and [=paintable=].
+        NOTE: This paint must include elements that are both [=contentful=] and [=paintable=].
 
         NOTE: A parent frame should not be aware of the paint events from its child iframes, and vice versa. This means that a frame that contains just iframes will have [=first paint=] (due to the enclosing boxes of the iframes) but no [=first contentful paint=].
 </div>

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -48,6 +48,12 @@ urlPrefix: https://w3c.github.io/IntersectionObserver/
     type: dfn; text: Intersection rect algorithm; url: #calculate-intersection-rect-algo
 urlPrefix: https://drafts.csswg.org/css-cascade-4/
     type: dfn; text: computed; url: #computed-value;
+urlPrefix: https://html.spec.whatwg.org/multipage/dom.html
+    type: dfn; text: element; url: #element;
+urlPrefix: https://drafts.csswg.org/css-pseudo-4
+    type: dfn; text: generated content pseudo-element; url: #generated-content;
+urlPrefix: https://www.w3.org/TR/cssom-view
+    type: dfn; text: getBoundingClientRect; url: #getBoundingClientRect;
 </pre>
 
 Introduction {#intro}
@@ -90,25 +96,28 @@ Formally, we consider the user agent to have "rendered" a document when it has p
 
     NOTE: The rendering pipeline is very complex, and the timestamp should be the latest timestamp the user agent is able to note in this pipeline (best effort). Typically the time at which the frame is submitted to the OS for display is recommended for this API.
 
-<dfn>Contentful</dfn>: An element counts as contentful when one or more of the following apply:
-* The element has a [=text node=] descendant, with at least one character, excluding [=document white space characters=].
+<dfn>Contentful</dfn>: An [=element=] or a [=pseudo-element=] counts as contentful when one or more of the following apply:
+* The element has a [=text node=] child, with at least one character, excluding [=document white space characters=].
 * The element is a [=replaced image=] representing a [=loaded=] image.
-* The element's current style contains a [=loaded=] [=background-image=] or [=mask-image=].
+* The element's [=computed=] style contains a [=loaded=] [=background-image=].
 * The element is a [=canvas=] with its [=context mode=] set to any value other than <code>none</code>.
 * The element is an [=svg element with rendered descendants=].
+* The element's [=computed=] style contains a [=contentful=] and [=paintable=] [=generated content pseudo-element=].
 
-<dfn>Paintable</dfn>: An element counts as paintable when all of the following apply:
-* The element intersects with the document, as defined by [=Intersection rect algorithm=]. 
-
-    NOTE: This covers the cases where the element is transformed to zero size, or is positioned in negative coordinates,
-
+<dfn>Paintable</dfn>: An [=element=] or a [=generated content pseudo-element=] counts as paintable when all of the following apply:
 * The element's [=computed=] [=visibility=] is <code>visible</code>.
-* The element is not fully transparent, as defined  [=computed=] [=opacity=] is greater than 0.
-* All of the element's ancestors have [=computed=] [=opacity=]
+* The element and all of its ancestors have positive [=computed=] [=opacity=].
+
+    NOTE: there could be cases where a <code>paintable</code> element would not be visible to the user, for example in the case of text that has the same color as its background.
+    Those elements would still considered as paintable for the purpose of computing [=first contentful paint=].    
+
+* The element's bounding rect, as returned by [=getBoundingClientRect=] has non-zero width and height, after applying clipping as defined in [=Intersection rect algorithm=], but without clipping to the [=viewport=]. 
+    
+    NOTE: This covers the cases where the element is scaled to zero size, has <code>display: none</code>, or <code>display: contents</code> where the contents resolve to an empty rect.
 
 <dfn export>First paint</dfn> entry contains a {{DOMHighResTimeStamp}} reporting the time when the user agent first rendered after navigation. This excludes the default background paint, but includes non-default background paint and the enclosing box of an iframe. This is the first key moment developers care about in page load – when the user agent has started to render the page.
 
-<dfn export>First contentful paint</dfn> entry contains a {{DOMHighResTimeStamp}} reporting the time when the user agent first rendered an element or part of an element which counts as [=contentful=] and [=paintable=].
+<dfn export>First contentful paint</dfn> entry contains a {{DOMHighResTimeStamp}} reporting the time when the user agent first rendered a [=document=] which includes at least one [=element=] that is both [=contentful=] and [=paintable=].
 
 Whenever a user agent preemptively paints content outside of the [=viewport=], those paints must be considered for [=first paint=] and [=first contentful paint=].
 

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -32,7 +32,8 @@ urlPrefix: https://www.w3.org/TR/CSS22/visufx.html; spec: CSS-2;
 urlPrefix: https://www.w3.org/TR/css-color-3; spec: CSS-COLOR-3;
     type: dfn; url: #opacity; text: opacity;
 urlPrefix: https://html.spec.whatwg.org/multipage/images.html
-    type: dfn; text: fully decodable image; url: #img-good
+    type: dfn; text: available; url: #img-available;
+    type: dfn; text: image; url: #images;
 urlPrefix: https://www.w3.org/TR/SVG2/render.html; spec: CR-SVG2
     type: dfn; url: #Rendered-vs-NonRendered; text: svg element with rendered descendants;
 urlPrefix: https://www.w3.org/TR/css-backgrounds-3/; spec: CSS-BACKGROUNDS-3;
@@ -59,7 +60,7 @@ urlPrefix: https://www.w3.org/TR/css3-values/
 urlPrefix: https://drafts.fxtf.org/css-masking-1/
     type: dfn; text: clip-path; url: #the-clip-path;
 urlPrefix: https://www.w3.org/TR/css-images-3/
-    type: dfn; text: image; url: #typedef-image;    
+    type: dfn; text: CSS image; url: #typedef-image;
 </pre>
 
 Introduction {#intro}
@@ -107,13 +108,13 @@ A [=generated content pseudo-element=] is a <dfn>paintable pseudo-element</dfn> 
 * The pseudo-element's [=used=] [=opacity=] is greater than zero.
 * The pseudo-element generates a non-empty [=box=].
 
-A CSS [=image=] |img| is a <dfn>contentful image</dfn> when all of the following apply:
+A [=CSS image=] |img| is a <dfn>contentful image</dfn> when all of the following apply:
 * |img| is [=url valued=]
-* |img| represents a [=fully decodable image=]
+* |img| is [=available=].
 
 An [=element=] |target| is <dfn export>contentful</dfn> when one or more of the following apply:
 * |target| has a [=text node=] child, with at least one character, excluding [=document white space characters=].
-* |target| is a [=replaced element=] representing a [=fully decodable image=].
+* |target| is a [=replaced element=] representing an [=available=] [=image=].
 * |target| has a [=background-image=] which is a [=contentful image=], and its [=used=] [=background-size=] has non-zero width and height values.
 * |target| is a [=canvas=] with its [=context mode=] set to any value other than <code>none</code>.
 * |target| is an [=svg element with rendered descendants=].

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -32,7 +32,7 @@ urlPrefix: https://www.w3.org/TR/CSS22/visufx.html; spec: CSS-2;
 urlPrefix: https://www.w3.org/TR/css-color-3; spec: CSS-COLOR-3;
     type: dfn; url: #opacity; text: opacity;
 urlPrefix: https://html.spec.whatwg.org/multipage/images.html
-    type: dfn; text: completely available image; url: #img-all
+    type: dfn; text: fully decodable image; url: #img-good
 urlPrefix: https://www.w3.org/TR/SVG2/render.html; spec: CR-SVG2
     type: dfn; url: #Rendered-vs-NonRendered; text: svg element with rendered descendants;
 urlPrefix: https://www.w3.org/TR/css-backgrounds-3/; spec: CSS-BACKGROUNDS-3;
@@ -109,19 +109,20 @@ A [=generated content pseudo-element=] is a <dfn>paintable pseudo-element</dfn> 
 
 An [=element=] |target| is <dfn export>contentful</dfn> when one or more of the following apply:
 * |target| has a [=text node=] child, with at least one character, excluding [=document white space characters=].
-* |target| is a [=replaced element=] representing a [=completely available image=].
-* |target| has a [=url valued=] [=image=] [=background-image=], and its [=used=] [=background-size=] has non-zero width and height values.
+* |target| is a [=replaced element=] representing a [=fully decodable image=].
+* |target| has a [=background-image=] which is a [=url valued=] [=fully decodable image=], and its [=used=] [=background-size=] has non-zero width and height values.
 * |target| is a [=canvas=] with its [=context mode=] set to any value other than <code>none</code>.
 * |target| is an [=svg element with rendered descendants=].
-* |target| is an [=originating element=] for a [=paintable pseudo-element=] that represents a [=completely available image=] or text with at least one character excluding [=document white space characters=].
+* |target| is an [=originating element=] for a [=paintable pseudo-element=] that represents a [=fully decodable image=] [=or text with at least one character excluding [=document white space characters=].
 
-To compute the <dfn>paintable bounding rect</dfn> of [=element=] |target|, The  is the result of the following algorithm:
+To compute the <dfn>paintable bounding rect</dfn> of [=element=] |target|, run the following steps:
     1. Let |boundingRect| be the result of running the [=getBoundingClientRect=] on |target|.
     1. Let |container| be the [=containing block=] of |target|.
     1. While |container| is not the [=document=]
         1. If container has <code>overflow: clip</code>, or its [=used=] style a css [=clip-path=] property, update |boundingRect| by applying |container|’s clip.
         1. Update |container| to be the [=containing block=] of |container|.
     1. Clip |boundingRect| with the [=document=]'s [=scrolling area=].
+    1. Return |boundingRect|.
 
     NOTE: elements contained by boxes with <code>overflow: scroll</code> or <code>overflow: hidden</code> don't have their [=paintable bounding rect=] clipped, as in both cases the [=element=] can become visible by scrolling.
 

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -109,7 +109,7 @@ A [=generated content pseudo-element=] is a <dfn>paintable pseudo-element</dfn> 
 * The pseudo-element generates a non-empty [=box=].
 
 A [=CSS image=] |img| is a <dfn>contentful image</dfn> when all of the following apply:
-* |img| is [=url valued=]
+* |img| is [=url valued=].
 * |img| is [=available=].
 
 An [=element=] |target| is <dfn export>contentful</dfn> when one or more of the following apply:

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -27,6 +27,25 @@ urlPrefix: https://www.w3.org/TR/hr-time-2/#idl-def-domhighrestimestamp; spec: H
     type: typedef; text: DOMHighResTimeStamp
 urlPrefix: https://www.w3.org/TR/CSS2/visuren.html; spec: CSS-2;
     type: dfn; url: #viewport; text: viewport
+urlPrefix: https://www.w3.org/TR/cssom-view/; spec: CSSOM-VIEW-1;
+    type: dfn; text: getBoundingClientRect; url: #dom-element-getboundingclientrect
+urlPrefix: https://dom.spec.whatwg.org/; spec: DOM
+    type: dfn; text: text node; url: #text
+urlPrefix: https://www.w3.org/TR/css-images-3/#url-notation; spec: CSS-IMAGES-3;
+    type: dfn; text: loaded; url: #typedef-image
+urlPrefix: https://www.w3.org/TR/SVG2/render.html; spec: CR-SVG2
+    type: dfn; url: #Rendered-vs-NonRendered; text: svg element with rendered descendants;
+urlPrefix: https://www.w3.org/TR/css-text-3; spec: CSS-TEXT-3;
+    type: dfn; text: white-space; url: #white-space;
+urlPrefix: https://www.w3.org/TR/css-backgrounds-3/; spec: CSS-BACKGROUNDS-3;
+    type: dfn; text: background-image; url: #propdef-background-image;
+urlPrefix: https://www.w3.org/TR/css-backgrounds-3/; spec: CSS-MASKING-1;
+    type: dfn; text: mask-image; url: #the-mask-image;
+urlPrefix: https://html.spec.whatwg.org/
+    type: dfn; text: canvas; url: #the-canvas-element;
+    type: dfn; text: context mode; url: #concept-canvas-context-mode;
+    type: dfn; text: replaced image; url: #images-3;
+
 </pre>
 
 Introduction {#intro}
@@ -69,9 +88,16 @@ Formally, we consider the user agent to have "rendered" a document when it has p
 
     NOTE: The rendering pipeline is very complex, and the timestamp should be the latest timestamp the user agent is able to note in this pipeline (best effort). Typically the time at which the frame is submitted to the OS for display is recommended for this API.
 
+<dfn export>Contentful</dfn>: An element counts as contentful when one or more of the following apply:
+* The element contains a [=text node=], with at least one character, excluding [=white-space=].
+* The element is a [=replaced image=] representing a [=loaded=] image.
+* The element's current style contains a [=loaded=] [=background-image=] or [=mask-image=].
+* The element is a [=canvas=] with its [=context mode=] set to any value other than <code>none</code>.
+* The element is an [=svg element with rendered descendants=].
+
 <dfn export>First paint</dfn> entry contains a {{DOMHighResTimeStamp}} reporting the time when the user agent first rendered after navigation. This excludes the default background paint, but includes non-default background paint and the enclosing box of an iframe. This is the first key moment developers care about in page load – when the user agent has started to render the page.
 
-<dfn export>First contentful paint</dfn> entry contains a {{DOMHighResTimeStamp}} reporting the time when the user agent first rendered any text, image (including background images), non-white canvas or SVG. This excludes any content of iframes, but includes text with pending webfonts. This is the first time users could start consuming page content.
+<dfn export>First contentful paint</dfn> entry contains a {{DOMHighResTimeStamp}} reporting the time when the user agent first rendered an element or part of an element which counts as [=contentful=], and has a non-empty bounding rect, as returned by [=getBoundingClientRect=].
 
 Whenever a user agent preemptively paints content outside of the [=viewport=], those paints must be considered for [=first paint=] and [=first contentful paint=].
 
@@ -115,7 +141,7 @@ Reporting paint timing {#sec-reporting-paint-timing}
 
     1. If this instance of [=update the rendering=] is the [=first contentful paint=] of |document|, then invoke the [[#report-paint-timing]] algorithm with |document|, <code>"first-contentful-paint"</code>, and |paintTimestamp| as arguments.
 
-        NOTE: This paint must include text, image (including background images), non-white canvas or SVG.
+        NOTE: This paint must include [=contentful=] elemenets with a non empty bounding rect as defined in [=getBoundingClientRect=].
 
         NOTE: A parent frame should not be aware of the paint events from its child iframes, and vice versa. This means that a frame that contains just iframes will have [=first paint=] (due to the enclosing boxes of the iframes) but no [=first contentful paint=].
 </div>

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -111,7 +111,7 @@ Formally, we consider the user agent to have "rendered" a document when it has p
     NOTE: there could be cases where a <code>paintable</code> element would not be visible to the user, for example in the case of text that has the same color as its background.
     Those elements would still considered as paintable for the purpose of computing [=first contentful paint=].    
 
-* The element's bounding rect, as returned by [=getBoundingClientRect=] has non-zero width and height, after applying clipping as defined in [=Intersection rect algorithm=], but without clipping to the [=viewport=]. 
+* The element's bounding rect, as returned by [=getBoundingClientRect=] has positive right, bottom, width and height, after applying clipping as defined in [=Intersection rect algorithm=], but without clipping to the [=viewport=]. 
     
     NOTE: This covers the cases where the element is scaled to zero size, has <code>display: none</code>, or <code>display: contents</code> where the contents resolve to an empty rect.
 

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -94,7 +94,7 @@ Formally, we consider the user agent to have "rendered" a document when it has p
 
     NOTE: The rendering pipeline is very complex, and the timestamp should be the latest timestamp the user agent is able to note in this pipeline (best effort). Typically the time at which the frame is submitted to the OS for display is recommended for this API.
 
-<dfn>Contentful</dfn>: An [=element=] counts as contentful when one or more of the following apply:
+An [=element=] is <dfn export>contentful</dfn> when one or more of the following apply:
 * The element has a [=text node=] child, with at least one character, excluding [=document white space characters=].
 * The element is a [=replaced element=] representing a [=loaded=] image.
 * The element's [=used=] style contains a [=loaded=] [=background-image=].

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -94,6 +94,10 @@ Formally, we consider the user agent to have "rendered" a document when it has p
 
     NOTE: The rendering pipeline is very complex, and the timestamp should be the latest timestamp the user agent is able to note in this pipeline (best effort). Typically the time at which the frame is submitted to the OS for display is recommended for this API.
 
+A [=generated content pseudo-element=] is a <dfn>paintable pseudo-element</dfn> when all of the following apply:
+* The pseudo-element's [=used=] [=visibility=] is <code>visible</code>.
+* The pseudo-element's [=used=] [=opacity=] is greater than zero.
+
 An [=element=] is <dfn export>contentful</dfn> when one or more of the following apply:
 * The element has a [=text node=] child, with at least one character, excluding [=document white space characters=].
 * The element is a [=replaced element=] representing a [=loaded=] image.
@@ -101,6 +105,10 @@ An [=element=] is <dfn export>contentful</dfn> when one or more of the following
 * The element is a [=canvas=] with its [=context mode=] set to any value other than <code>none</code>.
 * The element is an [=svg element with rendered descendants=].
 * The element is an [=originating element=] for a [=paintable pseudo-element=] that represents a [=loaded=] image or text with at least one character excluding [=document white space characters=].
+
+<dfn>Paintable Bounding Rect</dfn>: The paintable bounding rect is the [=element=]'s bounding rect, which would be the result of running the [=getBoundingClientRect=] algorithm on the [=element=], clipped by ancestors with <code>overflow: clip</code>.
+
+    NOTE: elements contained by boxes with <code>overflow: scroll</code> or <code>overflow: hidden</code> don't have their [=paintable bounding rect=] clipped, as in both cases the [=element=] can become visible by scrolling.
 
 An [=element=] is <dfn>paintable</dfn> when all of the following apply:
 * The element's [=used=] [=visibility=] is <code>visible</code>.
@@ -114,15 +122,6 @@ An [=element=] is <dfn>paintable</dfn> when all of the following apply:
     NOTE: This covers the cases where the element is scaled to zero size, has <code>display: none</code>, or <code>display: contents</code> where the contents resolve to an empty rect.
 
     NOTE: As a general rule, an [=element=] is paintable if it is within the viewport, or can potentially be in the viewport as a result of scrolling or zooming.
-
-A [=generated content pseudo-element=] is a <dfn>paintable pseudo-element</dfn> when all of the following apply:
-* The pseudo-element's [=used=] [=visibility=] is <code>visible</code>.
-* The pseudo-element's [=used=] [=opacity=] is greater than zero.
-
-<dfn>Paintable Bounding Rect</dfn>: The paintable bounding rect is the [=element=]'s bounding rect, which would be the result of running the [=getBoundingClientRect=] algorithm on the [=element=], clipped by ancestors with <code>overflow: clip</code>.
-
-    NOTE: elements contained by boxes with <code>overflow: scroll</code> or <code>overflow: hidden</code> don't have their [=paintable bounding rect=] clipped, as in both cases the [=element=] can become visible by scrolling.
-
 <dfn export>First paint</dfn> entry contains a {{DOMHighResTimeStamp}} reporting the time when the user agent first rendered after navigation. This excludes the default background paint, but includes non-default background paint and the enclosing box of an iframe. This is the first key moment developers care about in page load – when the user agent has started to render the page.
 
 <dfn export>First contentful paint</dfn> entry contains a {{DOMHighResTimeStamp}} reporting the time when the user agent first rendered a [=document=] which includes at least one [=element=] that is both [=contentful=] and [=paintable=].

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -107,13 +107,17 @@ A [=generated content pseudo-element=] is a <dfn>paintable pseudo-element</dfn> 
 * The pseudo-element's [=used=] [=opacity=] is greater than zero.
 * The pseudo-element generates a non-empty [=box=].
 
+A CSS [=image=] |img| is a <dfn>contentful image</dfn> when all of the following apply:
+* |img| is [=url valued=]
+* |img| represents a [=fully decodable image=]
+
 An [=element=] |target| is <dfn export>contentful</dfn> when one or more of the following apply:
 * |target| has a [=text node=] child, with at least one character, excluding [=document white space characters=].
 * |target| is a [=replaced element=] representing a [=fully decodable image=].
-* |target| has a [=background-image=] which is a [=url valued=] [=fully decodable image=], and its [=used=] [=background-size=] has non-zero width and height values.
+* |target| has a [=background-image=] which is a [=contentful image=], and its [=used=] [=background-size=] has non-zero width and height values.
 * |target| is a [=canvas=] with its [=context mode=] set to any value other than <code>none</code>.
 * |target| is an [=svg element with rendered descendants=].
-* |target| is an [=originating element=] for a [=paintable pseudo-element=] that represents a [=fully decodable image=] [=or text with at least one character excluding [=document white space characters=].
+* |target| is an [=originating element=] for a [=paintable pseudo-element=] that represents a [=contentful image=] or text with at least one character excluding [=document white space characters=].
 
 To compute the <dfn>paintable bounding rect</dfn> of [=element=] |target|, run the following steps:
     1. Let |boundingRect| be the result of running the [=getBoundingClientRect=] on |target|.

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -102,6 +102,9 @@ An [=element=] is <dfn export>contentful</dfn> when one or more of the following
 * The element has a [=text node=] child, with at least one character, excluding [=document white space characters=].
 * The element is a [=replaced element=] representing a [=loaded=] image.
 * The element's [=used=] style contains a [=loaded=] [=background-image=].
+
+    NOTE: a gradient is not considered a loaded background image, and thus would not make an element count as contentful.
+
 * The element is a [=canvas=] with its [=context mode=] set to any value other than <code>none</code>.
 * The element is an [=svg element with rendered descendants=].
 * The element is an [=originating element=] for a [=paintable pseudo-element=] that represents a [=loaded=] image or text with at least one character excluding [=document white space characters=].

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -31,8 +31,8 @@ urlPrefix: https://www.w3.org/TR/CSS22/visufx.html; spec: CSS-2;
     type: dfn; url: #propdef-visibility; text: visibility;
 urlPrefix: https://www.w3.org/TR/css-color-3; spec: CSS-COLOR-3;
     type: dfn; url: #opacity; text: opacity;
-urlPrefix: https://www.w3.org/TR/css-images-3/; spec: CSS-IMAGES-3;
-    type: dfn; text: loaded; url: #typedef-image
+urlPrefix: https://html.spec.whatwg.org/multipage/images.html
+    type: dfn; text: completely available image; url: #img-all
 urlPrefix: https://www.w3.org/TR/SVG2/render.html; spec: CR-SVG2
     type: dfn; url: #Rendered-vs-NonRendered; text: svg element with rendered descendants;
 urlPrefix: https://www.w3.org/TR/css-backgrounds-3/; spec: CSS-BACKGROUNDS-3;
@@ -54,6 +54,12 @@ urlPrefix: https://drafts.csswg.org/css-pseudo-4
 urlPrefix: https://www.w3.org/TR/cssom-view
     type: dfn; text: getBoundingClientRect; url: #dom-element-getboundingclientrect;
     type: dfn; text: scrolling area; url: #scrolling-area;
+urlPrefix: https://www.w3.org/TR/css3-values/
+    type: dfn; text: url valued; url: #url-value;
+urlPrefix: https://drafts.fxtf.org/css-masking-1/
+    type: dfn; text: clip-path; url: #the-clip-path;
+urlPrefix: https://www.w3.org/TR/css-images-3/
+    type: dfn; text: image; url: #typedef-image;    
 </pre>
 
 Introduction {#intro}
@@ -101,29 +107,32 @@ A [=generated content pseudo-element=] is a <dfn>paintable pseudo-element</dfn> 
 * The pseudo-element's [=used=] [=opacity=] is greater than zero.
 * The pseudo-element generates a non-empty [=box=].
 
-An [=element=] is <dfn export>contentful</dfn> when one or more of the following apply:
-* The element has a [=text node=] child, with at least one character, excluding [=document white space characters=].
-* The element is a [=replaced element=] representing a [=loaded=] image.
-* The element has a [=loaded=] [=background-image=], and its [=used=] [=background-size=] has non-zero width and height values.
+An [=element=] |target| is <dfn export>contentful</dfn> when one or more of the following apply:
+* |target| has a [=text node=] child, with at least one character, excluding [=document white space characters=].
+* |target| is a [=replaced element=] representing a [=completely available image=].
+* |target| has a [=url valued=] [=image=] [=background-image=], and its [=used=] [=background-size=] has non-zero width and height values.
+* |target| is a [=canvas=] with its [=context mode=] set to any value other than <code>none</code>.
+* |target| is an [=svg element with rendered descendants=].
+* |target| is an [=originating element=] for a [=paintable pseudo-element=] that represents a [=completely available image=] or text with at least one character excluding [=document white space characters=].
 
-    NOTE: a gradient is not considered a loaded background image, and thus would not make an element count as contentful.
-
-* The element is a [=canvas=] with its [=context mode=] set to any value other than <code>none</code>.
-* The element is an [=svg element with rendered descendants=].
-* The element is an [=originating element=] for a [=paintable pseudo-element=] that represents a [=loaded=] image or text with at least one character excluding [=document white space characters=].
-
-<dfn>Paintable Bounding Rect</dfn>: The paintable bounding rect is the [=element=]'s bounding rect, which would be the result of running the [=getBoundingClientRect=] algorithm on the [=element=], clipped by ancestors with <code>overflow: clip</code>.
+To compute the <dfn>paintable bounding rect</dfn> of [=element=] |target|, The  is the result of the following algorithm:
+    1. Let |boundingRect| be the result of running the [=getBoundingClientRect=] on |target|.
+    1. Let |container| be the [=containing block=] of |target|.
+    1. While |container| is not the [=document=]
+        1. If container has <code>overflow: clip</code>, or its [=used=] style a css [=clip-path=] property, update |boundingRect| by applying |container|’s clip.
+        1. Update |container| to be the [=containing block=] of |container|.
+    1. Clip |boundingRect| with the [=document=]'s [=scrolling area=].
 
     NOTE: elements contained by boxes with <code>overflow: scroll</code> or <code>overflow: hidden</code> don't have their [=paintable bounding rect=] clipped, as in both cases the [=element=] can become visible by scrolling.
 
-An [=element=] is <dfn>paintable</dfn> when all of the following apply:
-* The element's [=used=] [=visibility=] is <code>visible</code>.
-* The element and all of its ancestors' [=used=] [=opacity=] is greater than zero.
+An [=element=] |el| is <dfn>paintable</dfn> when all of the following apply:
+* |el|'s [=used=] [=visibility=] is <code>visible</code>.
+* |el| and all of its ancestors' [=used=] [=opacity=] is greater than zero.
 
     NOTE: there could be cases where a <code>paintable</code> [=element=] would not be visible to the user, for example in the case of text that has the same color as its background.
     Those elements would still considered as paintable for the purpose of computing [=first contentful paint=].    
 
-* The element's [=paintable bounding rect=] intersects with the [=scrolling area=] of the [=document=]. 
+* |el|'s [=paintable bounding rect=] intersects with the [=scrolling area=] of the [=document=]. 
     
     NOTE: This covers the cases where the element is scaled to zero size, has <code>display: none</code>, or <code>display: contents</code> where the contents resolve to an empty rect.
 


### PR DESCRIPTION
A shot at better defining what "contentful" means in the context of "first contentful paint". Added "contentful" to the terminology with an attempt at a precise definition with proper references.
Gave clear definitions of images, canvas, text, and paint rects.

(This is my first try at one of these specs so please bear with me...)

@rniwa, @npm1  wdyt?
<!--
  Changing comment to see if that fixes PR Preview
-->


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/paint-timing/pull/66.html" title="Last updated on Mar 20, 2020, 7:07 AM UTC (a9fa4a4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/paint-timing/66/2af3ad3...a9fa4a4.html" title="Last updated on Mar 20, 2020, 7:07 AM UTC (a9fa4a4)">Diff</a>