### PR TITLE
Pass document as input to paint timing algorithms

### DIFF
--- a/painttiming.bs
+++ b/painttiming.bs
@@ -96,21 +96,19 @@ Processing model {#sec-processing-model}
 Reporting paint timing {#sec-reporting-paint-timing}
 --------------------------------------------------------
 
-<h4 dfn>Mark paint timing</h4>
+<h4 dfn export>Mark paint timing</h4>
 
 <div algorithm="Mark paint timing">
-    Perform the following steps:
+    When asked to [=mark paint timing=] given a [=Document=] |document| as input, perform the following steps:
 
-    1. Let |paintTimestamp| be the input timestamp.
-    1. If this instance of [=update the rendering=] is the [=first paint=], then record the timestamp as |paintTimestamp| and invoke the [[#report-paint-timing]] algorithm with two arguments: <code>"first-paint"</code> and |paintTimestamp|.
+    1. Let |paintTimestamp| be the [=current high resolution time=].
+    1. If this instance of [=update the rendering=] is the [=first paint=] of |document|, then invoke the [[#report-paint-timing]] algorithm with |document|, <code>"first-paint"</code>, and |paintTimestamp|.
 
         NOTE: [=First paint=] excludes the default background paint, but includes non-default background paint.
 
-    1. Otherwise, if this instance of [=update the rendering=] is the [=first contentful paint</a>, then record the timestamp as |paintTimestamp| and invoke the [[#report-paint-timing]] algorithm with two arguments: <code>"first-contentful-paint"</code> and |paintTimestamp|.
+    1. If this instance of [=update the rendering=] is the [=first contentful paint=] of |document|, then invoke the [[#report-paint-timing]] algorithm with |document|, <code>"first-contentful-paint"</code>, and |paintTimestamp| as arguments.
 
         NOTE: This paint must include text, image (including background images), non-white canvas or SVG.
-
-    1. Otherwise, do nothing and return.
 
         NOTE: A parent frame should not be aware of the paint events from its child iframes, and vice versa. This means that a frame that contains just iframes will have [=first paint=] (due to the enclosing boxes of the iframes) but no [=first contentful paint=].
 </div>
@@ -118,13 +116,13 @@ Reporting paint timing {#sec-reporting-paint-timing}
 <h4 dfn>Report paint timing</h4>
 
 <div algorithm="Report paint timing">
-    Given two arguments |paintType| and |paintTimestamp|, perform the following steps:
+    When asked to [=report paint timing=] given |document|, |paintType|, and |paintTimestamp| as arguments, perform the following steps:
     1. Create a new {{PerformancePaintTiming}} object |newEntry| and set its attributes as follows:
-        1. Set |newEntry|'s {{PerformanceEntry/name}} attribute to |paintType|
-        1. Set |newEntry|'s {{PerformanceEntry/entryType}} attribute to <code>paint</code>
-        1. Set |newEntry|'s {{PerformanceEntry/startTime}} attribute to |paintTimestamp|
+        1. Set |newEntry|'s {{PerformanceEntry/name}} attribute to |paintType|.
+        1. Set |newEntry|'s {{PerformanceEntry/entryType}} attribute to <code>"paint"</code>.
+        1. Set |newEntry|'s {{PerformanceEntry/startTime}} attribute to |paintTimestamp|.
         1. Set |newEntry|'s {{PerformanceEntry/duration}} attribute to 0.
-    1. <a href="https://w3c.github.io/performance-timeline/#dfn-queue-a-performanceentry">Add the PerformanceEntry</a> |newEntry| object.
+    1. <a href="https://w3c.github.io/performance-timeline/#dfn-queue-a-performanceentry">Add the PerformanceEntry</a> |newEntry| object, with |document|'s [=relevant global object=] as input.
 </div>
 
 


### PR DESCRIPTION
Since these algorithms are called from the event loop directly, we need to specify the Documents explicitly. In addition, https://github.com/w3c/performance-timeline/issues/162 has been filed to track the change to Performance Timeline to support receiving the global object as argument to the "queue an entry" algorithm. Relevant issue: https://github.com/w3c/paint-timing/issues/62


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/paint-timing/pull/67.html" title="Last updated on Mar 9, 2020, 9:21 PM UTC (23e5f05)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/paint-timing/67/ecfe84e...23e5f05.html" title="Last updated on Mar 9, 2020, 9:21 PM UTC (23e5f05)">Diff</a>