### PR TITLE
Improve wording in introduction

### DIFF
--- a/painttiming.bs
+++ b/painttiming.bs
@@ -38,9 +38,9 @@ Introduction {#intro}
 
 Load is not a single moment in time — it's an experience that no one metric can fully capture. There are multiple moments during the load experience that can affect whether a user perceives it as "fast" or "slow".
 
-First paint (FP) is the first of these key moments, followed by first contentful paint (FCP). These metrics mark the points in time when the browser renders pixels to the screen. This is important to the user because it answers the question: is it happening?
+First paint (FP) is the first of these key moments, followed by first contentful paint (FCP). These metrics mark the points in time when the browser renders a given document. This is important to the user because it answers the question: is it happening?
 
-The primary difference between the two metrics is FP marks the point when the browser renders anything from the document. By contrast, FCP is the point when the browser renders the first bit of image or text content from the DOM.
+The primary difference between the two metrics is FP marks the first time the browser renders anything for a given document. By contrast, FCP marks the time when the browser renders the first bit of image or text content from the DOM.
 
 Usage example {#example}
 ------------------------

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -31,11 +31,16 @@ urlPrefix: https://www.w3.org/TR/CSS2/visuren.html; spec: CSS-2;
 
 Introduction {#intro}
 =====================
+
+<div class=non-normative>
+
+<em>This section is non-normative.</em>
+
 Load is not a single moment in time — it's an experience that no one metric can fully capture. There are multiple moments during the load experience that can affect whether a user perceives it as "fast" or "slow".
 
-First paint (FP) is the first of these key moments, followed by first contentful paint (FCP). These metrics mark the points, immediately after navigation, when the browser renders pixels to the screen. This is important to the user because it answers the question: is it happening?
+First paint (FP) is the first of these key moments, followed by first contentful paint (FCP). These metrics mark the points in time when the browser renders pixels to the screen. This is important to the user because it answers the question: is it happening?
 
-The primary difference between the two metrics is FP marks the point when the browser renders anything that is visually different from what was on the screen prior to navigation. By contrast, FCP is the point when the browser renders the first bit of content from the DOM, which may be text, an image, SVG, or even a canvas element.
+The primary difference between the two metrics is FP marks the point when the browser renders anything from the document. By contrast, FCP is the point when the browser renders the first bit of image or text content from the DOM.
 
 Usage example {#example}
 ------------------------
@@ -53,6 +58,8 @@ Usage example {#example}
     // register observer for paint timing notifications
     observer.observe({entryTypes: ["paint"]});
 </pre>
+
+</div>
 
 Terminology {#sec-terminology}
 ==============================


### PR DESCRIPTION
This PR removes 'navigation' wording from the introduction, and marks the section as non-normative. Fixes https://github.com/w3c/paint-timing/issues/19


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: write EPROTO 139705468127104:error:1407742E:SSL routines:SSL23_GET_SERVER_HELLO:tlsv1 alert protocol version:../deps/openssl/openssl/ssl/s23_clnt.c:772:
 :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 12, 2020, 3:26 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [HTML Diff Service](http://services.w3.org/htmldiff) - The HTML Diff Service is used to create HTML diffs of the spec changes suggested in a pull request.

:link: [Related URL](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fw3c%2Fpaint-timing%2Fpull%2F68%2F3fe291f.html&doc2=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fw3c%2Fpaint-timing%2Fpull%2F68.html)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/paint-timing%2368.)._
</details>
