### PR TITLE
Clarify contentful video

### DIFF
--- a/painttiming.bs
+++ b/painttiming.bs
@@ -50,6 +50,7 @@ urlPrefix: https://drafts.csswg.org/css-cascade-4/
     type: dfn; text: used; url: #used;
 urlPrefix: https://html.spec.whatwg.org/multipage/dom.html
     type: dfn; text: element; url: #element;
+    type: dfn; text: represents; url: #represents;
 urlPrefix: https://drafts.csswg.org/css-pseudo-4
     type: dfn; text: generated content pseudo-element; url: #generated-content;
 urlPrefix: https://www.w3.org/TR/cssom-view
@@ -61,6 +62,9 @@ urlPrefix: https://drafts.fxtf.org/css-masking-1/
     type: dfn; text: clip-path; url: #the-clip-path;
 urlPrefix: https://www.w3.org/TR/css-images-3/
     type: dfn; text: CSS image; url: #typedef-image;
+urlPrefix: https://html.spec.whatwg.org/multipage/media.html
+    type: dfn; text: poster frame; url: #poster-frame;
+    type: dfn; text: video element; url: #the-video-element;
 </pre>
 
 Introduction {#intro}
@@ -117,8 +121,9 @@ An [=element=] |target| is <dfn export>contentful</dfn> when one or more of the 
 * |target| is a [=replaced element=] representing an [=available=] [=image=].
 * |target| has a [=background-image=] which is a [=contentful image=], and its [=used=] [=background-size=] has non-zero width and height values.
 * |target| is a [=canvas=] with its [=context mode=] set to any value other than <code>none</code>.
+* |target| is a [=video element=] that [=represents=] its [=poster frame=] or the first video frame.
 * |target| is an [=svg element with rendered descendants=].
-* |target| is an [=originating element=] for a [=paintable pseudo-element=] that represents a [=contentful image=] or text with at least one character excluding [=document white space characters=].
+* |target| is an [=originating element=] for a [=paintable pseudo-element=] that [=represents=] a [=contentful image=] or text with at least one character excluding [=document white space characters=].
 
 To compute the <dfn>paintable bounding rect</dfn> of [=element=] |target|, run the following steps:
     1. Let |boundingRect| be the result of running the [=getBoundingClientRect=] on |target|.

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -121,7 +121,7 @@ An [=element=] |target| is <dfn export>contentful</dfn> when one or more of the 
 * |target| is a [=replaced element=] representing an [=available=] [=image=].
 * |target| has a [=background-image=] which is a [=contentful image=], and its [=used=] [=background-size=] has non-zero width and height values.
 * |target| is a [=canvas=] with its [=context mode=] set to any value other than <code>none</code>.
-* |target| is a [=video element=] that [=represents=] its [=poster frame=] or the first video frame.
+* |target| is a [=video element=] that [=represents=] its [=poster frame=] or the first video frame and the frame is available.
 * |target| is an [=svg element with rendered descendants=].
 * |target| is an [=originating element=] for a [=paintable pseudo-element=] that represents a [=contentful image=] or text with at least one character excluding [=document white space characters=].
 

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -123,7 +123,7 @@ An [=element=] |target| is <dfn export>contentful</dfn> when one or more of the 
 * |target| is a [=canvas=] with its [=context mode=] set to any value other than <code>none</code>.
 * |target| is a [=video element=] that [=represents=] its [=poster frame=] or the first video frame.
 * |target| is an [=svg element with rendered descendants=].
-* |target| is an [=originating element=] for a [=paintable pseudo-element=] that [=represents=] a [=contentful image=] or text with at least one character excluding [=document white space characters=].
+* |target| is an [=originating element=] for a [=paintable pseudo-element=] that represents a [=contentful image=] or text with at least one character excluding [=document white space characters=].
 
 To compute the <dfn>paintable bounding rect</dfn> of [=element=] |target|, run the following steps:
     1. Let |boundingRect| be the result of running the [=getBoundingClientRect=] on |target|.


### PR DESCRIPTION
Clarify that also a first frame of a video is considered contentful


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/paint-timing/pull/70.html" title="Last updated on Mar 20, 2020, 4:16 PM UTC (1088f67)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/paint-timing/70/529a022...1088f67.html" title="Last updated on Mar 20, 2020, 4:16 PM UTC (1088f67)">Diff</a>