### PR TITLE
Clarify that availability of paint-API is limited to a particular browsing context.

### DIFF
--- a/painttiming.bs
+++ b/painttiming.bs
@@ -71,6 +71,8 @@ urlPrefix: https://html.spec.whatwg.org/multipage/input.html
 urlPrefix: https://html.spec.whatwg.org/multipage/browsers.html
     type: dfn; text: browsing context; url: #browsing-context;
     type: dfn; text: nested browsing context; url: #nested-browsing-context;
+urlPrefix: https://html.spec.whatwg.org/multipage/webappapis.html
+    type: dfn; text: global object; url: #concept-realm-global;
 
 </pre>
 
@@ -163,6 +165,13 @@ An [=element=] |el| is <dfn>paintable</dfn> when all of the following apply:
 
 <dfn export>First contentful paint</dfn> entry contains a {{DOMHighResTimeStamp}} reporting the time when the user agent first rendered a [=document=] which includes at least one [=element=] that is both [=contentful=] and [=paintable=].
 
+A [=browsing context=] |ctx| is <dfn>paint-timing eligible</dfn> when one of the following apply:
+* |ctx| is a [=top-level browsing context=].
+* |ctx| is a [=nested browsing context=], and the user agent has allowed |ctx| to report paint timing.
+
+    NOTE: this allows user-agents to enable paint-timing only for some of the frames, in addition to the main frame, if they so choose.
+    For example, a user-agent may decide to disable paint-timing for cross-origin iframes.
+
 The {{PerformancePaintTiming}} interface {#sec-PerformancePaintTiming}
 =======================================
 
@@ -180,7 +189,7 @@ The {{PerformancePaintTiming}} interface {#sec-PerformancePaintTiming}
 * The {{PerformanceEntry/startTime}} attribute's getter must return a {{DOMHighResTimeStamp}} of when the paint occured.
 * The {{PerformanceEntry/duration}} attribute's getter must return 0.
 
-NOTE: A user agent implementing {{PerformancePaintTiming}} would need to include <code>"paint"</code> in {{PerformanceObserver/supportedEntryTypes}} for a [=global object=] associated with a [=browsing context=] that supports paint timing.
+NOTE: A user agent implementing {{PerformancePaintTiming}} would need to include <code>"paint"</code> in {{PerformanceObserver/supportedEntryTypes}} for a [=global object=] associated with a [=paint-timing eligible=] [=browsing context=].
 This allows developers to detect support for paint timing for a particular [=browsing context=].
 
 Processing model {#sec-processing-model}
@@ -193,11 +202,7 @@ Reporting paint timing {#sec-reporting-paint-timing}
 
 <div algorithm="Mark paint timing">
     When asked to [=mark paint timing=] given a [=Document=] |document| as input, perform the following steps:
-    1. If the [=document=]'s [=browsing context=] |ctx| is a [=nested browsing context=] and paint-timing is not enabled for |ctx|, return.
-
-        NOTE: this allows user-agents to enable paint-timing only for some of the frames, in addition to the main frame, if they so choose.
-        For example, a user-agent may decide to disable paint-timing for cross-origin iframes.
-
+    1. If the [=document=]'s [=browsing context=] is not an [=paint-timing eligible=] [=browsing context=], return.
     1. Let |paintTimestamp| be the [=current high resolution time=].
     1. If this instance of [=update the rendering=] is the [=first paint=] of |document|, then invoke the [[#report-paint-timing]] algorithm with |document|, <code>"first-paint"</code>, and |paintTimestamp|.
 

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -169,7 +169,7 @@ A [=browsing context=] |ctx| is <dfn>paint-timing eligible</dfn> when one of the
 * |ctx| is a [=nested browsing context=], and the user agent has configured |ctx| to report paint timing.
 
     NOTE: this allows user-agents to enable paint-timing only for some of the frames, in addition to the main frame, if they so choose.
-    For example, a user-agent may decide to disable paint-timing for cross-origin iframes.
+    For example, a user-agent may decide to disable paint-timing for cross-origin iframes, as in some scenarios their paint-timing might reveal information about the main frame.
 
 The {{PerformancePaintTiming}} interface {#sec-PerformancePaintTiming}
 =======================================

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -71,7 +71,8 @@ urlPrefix: https://html.spec.whatwg.org/multipage/input.html
 urlPrefix: https://html.spec.whatwg.org/multipage/browsers.html
     type: dfn; text: browsing context; url: #browsing-context;
     type: dfn; text: nested browsing context; url: #nested-browsing-context;
-
+urlPrefix: https://html.spec.whatwg.org/multipage/webappapis.html
+    type: dfn; text: global object; url: #concept-realm-global;
 </pre>
 
 Introduction {#intro}
@@ -165,7 +166,7 @@ An [=element=] |el| is <dfn>paintable</dfn> when all of the following apply:
 
 A [=browsing context=] |ctx| is <dfn>paint-timing eligible</dfn> when one of the following apply:
 * |ctx| is a [=top-level browsing context=].
-* |ctx| is a [=nested browsing context=], and the user agent has allowed |ctx| to report paint timing.
+* |ctx| is a [=nested browsing context=], and the user agent has configured |ctx| to report paint timing.
 
     NOTE: this allows user-agents to enable paint-timing only for some of the frames, in addition to the main frame, if they so choose.
     For example, a user-agent may decide to disable paint-timing for cross-origin iframes.
@@ -187,7 +188,7 @@ The {{PerformancePaintTiming}} interface {#sec-PerformancePaintTiming}
 * The {{PerformanceEntry/startTime}} attribute's getter must return a {{DOMHighResTimeStamp}} of when the paint occured.
 * The {{PerformanceEntry/duration}} attribute's getter must return 0.
 
-NOTE: A user agent implementing {{PerformancePaintTiming}} would need to include <code>"paint"</code> in {{PerformanceObserver/supportedEntryTypes}} where the [=relevant global object=] is associated with a [=paint-timing eligible=] [=browsing context=].
+NOTE: A user agent implementing {{PerformancePaintTiming}} would need to include <code>"paint"</code> in {{PerformanceObserver/supportedEntryTypes}} of a [=global object=], where its [=responsible browsing context=] is [=paint-timing eligible=].
 This allows developers to detect support for paint timing for a particular [=browsing context=].
 
 Processing model {#sec-processing-model}
@@ -200,7 +201,7 @@ Reporting paint timing {#sec-reporting-paint-timing}
 
 <div algorithm="Mark paint timing">
     When asked to [=mark paint timing=] given a [=Document=] |document| as input, perform the following steps:
-    1. If the [=document=]'s [=browsing context=] is not a [=paint-timing eligible=] [=browsing context=], return.
+    1. If the [=document=]'s [=browsing context=] is not [=paint-timing eligible=], return.
     1. Let |paintTimestamp| be the [=current high resolution time=].
     1. If this instance of [=update the rendering=] is the [=first paint=] of |document|, then invoke the [[#report-paint-timing]] algorithm with |document|, <code>"first-paint"</code>, and |paintTimestamp|.
 

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -71,12 +71,8 @@ urlPrefix: https://html.spec.whatwg.org/multipage/input.html
     type: dfn; text: value attribute; url: #attr-input-value;
 urlPrefix: https://html.spec.whatwg.org/multipage/browsers.html
     type: dfn; text: browsing context; url: #browsing-context;
-    type: dfn; text: browsing context; url: #browsing-context;
     type: dfn; text: top level browsing context; url: #top-level-browsing-context;
     type: dfn; text: nested browsing context; url: #nested-browsing-context;
-
-urlPrefix: https://html.spec.whatwg.org/multipage/webappapis.html
-    type: dfn; text: global object; url: #global-object;
 
 </pre>
 
@@ -186,11 +182,8 @@ The {{PerformancePaintTiming}} interface {#sec-PerformancePaintTiming}
 * The {{PerformanceEntry/startTime}} attribute's getter must return a {{DOMHighResTimeStamp}} of when the paint occured.
 * The {{PerformanceEntry/duration}} attribute's getter must return 0.
 
-Extension to {{PerformanceObserver/supportedEntryTypes}} {#sec-extendSupportedEntryTypesWithPaint}
-=======================================
-To allow developers to detect support for paint timing, the [=frozen array of supported entry types=] must include <code>"paint"</code> if any of the following apply: 
-* The [=relevant global object=] ia associated with a [=top level browsing context=]
-* The [=relevant global object=] is associated with a [=nested browsing context=], and the user-agent would run the [=mark paint timing=] algorithm for the [=document=] associated for that [=browsing context=].
+NOTE: A user agent implementing {{PerformancePaintTiming}} would need to include <code>"paint"</code> in {{PerformanceObserver/supportedEntryTypes}} for any [=top level browsing context=], and may include it for any [=nested browsing context=].
+This allows developers to detect support for paint timing for a particular [=browsing context=].
 
 Processing model {#sec-processing-model}
 ========================================

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -201,7 +201,7 @@ Reporting paint timing {#sec-reporting-paint-timing}
 
 <div algorithm="Mark paint timing">
     When asked to [=mark paint timing=] given a [=Document=] |document| as input, perform the following steps:
-    1. If the [=document=]'s [=browsing context=] is not [=paint-timing eligible=], return.
+    1. If the [=document=]'s [=responsible browsing context=] is not [=paint-timing eligible=], return.
     1. Let |paintTimestamp| be the [=current high resolution time=].
     1. If this instance of [=update the rendering=] is the [=first paint=] of |document|, then invoke the [[#report-paint-timing]] algorithm with |document|, <code>"first-paint"</code>, and |paintTimestamp|.
 

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -180,7 +180,7 @@ The {{PerformancePaintTiming}} interface {#sec-PerformancePaintTiming}
 * The {{PerformanceEntry/startTime}} attribute's getter must return a {{DOMHighResTimeStamp}} of when the paint occured.
 * The {{PerformanceEntry/duration}} attribute's getter must return 0.
 
-NOTE: A user agent implementing {{PerformancePaintTiming}} would need to include <code>"paint"</code> in {{PerformanceObserver/supportedEntryTypes}} for any [=browsing context=] that supports it.
+NOTE: A user agent implementing {{PerformancePaintTiming}} would need to include <code>"paint"</code> in {{PerformanceObserver/supportedEntryTypes}} for a [=global object=] associated with a [=browsing context=] that supports paint timing.
 This allows developers to detect support for paint timing for a particular [=browsing context=].
 
 Processing model {#sec-processing-model}
@@ -196,7 +196,7 @@ Reporting paint timing {#sec-reporting-paint-timing}
     1. If the [=document=]'s [=browsing context=] |ctx| is a [=nested browsing context=] and paint-timing is not enabled for |ctx|, return.
 
         NOTE: this allows user-agents to enable paint-timing only for some of the frames, in addition to the main frame, if they so choose.
-        For example, a user-agent may decide to disable paint-timing for cross-origin IFrames.
+        For example, a user-agent may decide to disable paint-timing for cross-origin iframes.
 
     1. Let |paintTimestamp| be the [=current high resolution time=].
     1. If this instance of [=update the rendering=] is the [=first paint=] of |document|, then invoke the [[#report-paint-timing]] algorithm with |document|, <code>"first-paint"</code>, and |paintTimestamp|.

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -200,9 +200,7 @@ Reporting paint timing {#sec-reporting-paint-timing}
         For example, a user-agent may decide to disable paint-timing for cross-origin IFrames.
 
     1. Let |paintTimestamp| be the [=current high resolution time=].
-    1. If this instance of [=update the rendering=] is the [=first paint=] of |document|:
-        If the user-agent 
-        1. invoke the [[#report-paint-timing]] algorithm with |document|, <code>"first-paint"</code>, and |paintTimestamp|.
+    1. If this instance of [=update the rendering=] is the [=first paint=] of |document|, then invoke the [[#report-paint-timing]] algorithm with |document|, <code>"first-paint"</code>, and |paintTimestamp|.
 
         NOTE: [=First paint=] excludes the default background paint, but includes non-default background paint.
 

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -71,7 +71,6 @@ urlPrefix: https://html.spec.whatwg.org/multipage/input.html
     type: dfn; text: value attribute; url: #attr-input-value;
 urlPrefix: https://html.spec.whatwg.org/multipage/browsers.html
     type: dfn; text: browsing context; url: #browsing-context;
-    type: dfn; text: top level browsing context; url: #top-level-browsing-context;
     type: dfn; text: nested browsing context; url: #nested-browsing-context;
 
 </pre>
@@ -182,7 +181,7 @@ The {{PerformancePaintTiming}} interface {#sec-PerformancePaintTiming}
 * The {{PerformanceEntry/startTime}} attribute's getter must return a {{DOMHighResTimeStamp}} of when the paint occured.
 * The {{PerformanceEntry/duration}} attribute's getter must return 0.
 
-NOTE: A user agent implementing {{PerformancePaintTiming}} would need to include <code>"paint"</code> in {{PerformanceObserver/supportedEntryTypes}} for any [=top level browsing context=], and may include it for any [=nested browsing context=].
+NOTE: A user agent implementing {{PerformancePaintTiming}} would need to include <code>"paint"</code> in {{PerformanceObserver/supportedEntryTypes}} for any [=browsing context=] that supports it.
 This allows developers to detect support for paint timing for a particular [=browsing context=].
 
 Processing model {#sec-processing-model}
@@ -195,9 +194,15 @@ Reporting paint timing {#sec-reporting-paint-timing}
 
 <div algorithm="Mark paint timing">
     When asked to [=mark paint timing=] given a [=Document=] |document| as input, perform the following steps:
+    1. If the [=document=]'s [=browsing context=] |ctx| is a [=nested browsing context=] and paint-timing is not enabled for |ctx|, return.
+
+        NOTE: this allows user-agents to enable paint-timing only for some of the frames, in addition to the main frame, if they so choose.
+        For example, a user-agent may decide to disable paint-timing for cross-origin IFrames.
 
     1. Let |paintTimestamp| be the [=current high resolution time=].
-    1. If this instance of [=update the rendering=] is the [=first paint=] of |document|, then invoke the [[#report-paint-timing]] algorithm with |document|, <code>"first-paint"</code>, and |paintTimestamp|.
+    1. If this instance of [=update the rendering=] is the [=first paint=] of |document|:
+        If the user-agent 
+        1. invoke the [[#report-paint-timing]] algorithm with |document|, <code>"first-paint"</code>, and |paintTimestamp|.
 
         NOTE: [=First paint=] excludes the default background paint, but includes non-default background paint.
 

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -71,8 +71,6 @@ urlPrefix: https://html.spec.whatwg.org/multipage/input.html
 urlPrefix: https://html.spec.whatwg.org/multipage/browsers.html
     type: dfn; text: browsing context; url: #browsing-context;
     type: dfn; text: nested browsing context; url: #nested-browsing-context;
-urlPrefix: https://html.spec.whatwg.org/multipage/webappapis.html
-    type: dfn; text: global object; url: #concept-realm-global;
 
 </pre>
 
@@ -189,7 +187,7 @@ The {{PerformancePaintTiming}} interface {#sec-PerformancePaintTiming}
 * The {{PerformanceEntry/startTime}} attribute's getter must return a {{DOMHighResTimeStamp}} of when the paint occured.
 * The {{PerformanceEntry/duration}} attribute's getter must return 0.
 
-NOTE: A user agent implementing {{PerformancePaintTiming}} would need to include <code>"paint"</code> in {{PerformanceObserver/supportedEntryTypes}} for a [=global object=] associated with a [=paint-timing eligible=] [=browsing context=].
+NOTE: A user agent implementing {{PerformancePaintTiming}} would need to include <code>"paint"</code> in {{PerformanceObserver/supportedEntryTypes}} where the [=relevant global object=] is associated with a [=paint-timing eligible=] [=browsing context=].
 This allows developers to detect support for paint timing for a particular [=browsing context=].
 
 Processing model {#sec-processing-model}

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -21,6 +21,7 @@ urlPrefix: https://www.w3.org/TR/performance-timeline-2/; spec: PERFORMANCE-TIME
         text: startTime; url: #dom-performanceentry-starttime
         text: duration; url: #dom-performanceentry-duration
     type: dfn; url: #dfn-register-a-performance-entry-type; text: register a performance entry type
+    type: dfn; url: #dfn-frozen-array-of-supported-entry-types; text: frozen array of supported entry types;
     type: attribute; for: PerformanceObserver;
         text: supportedEntryTypes; url: #supportedentrytypes-attribute
 urlPrefix: https://www.w3.org/TR/hr-time-2/#idl-def-domhighrestimestamp; spec: HR-TIME-2;
@@ -68,6 +69,14 @@ urlPrefix: https://html.spec.whatwg.org/multipage/media.html
 urlPrefix: https://html.spec.whatwg.org/multipage/input.html
     type: dfn; text: input; url: #the-input-element;
     type: dfn; text: value attribute; url: #attr-input-value;
+urlPrefix: https://html.spec.whatwg.org/multipage/browsers.html
+    type: dfn; text: browsing context; url: #browsing-context;
+    type: dfn; text: browsing context; url: #browsing-context;
+    type: dfn; text: top level browsing context; url: #top-level-browsing-context;
+    type: dfn; text: nested browsing context; url: #nested-browsing-context;
+
+urlPrefix: https://html.spec.whatwg.org/multipage/webappapis.html
+    type: dfn; text: global object; url: #global-object;
 
 </pre>
 
@@ -177,8 +186,11 @@ The {{PerformancePaintTiming}} interface {#sec-PerformancePaintTiming}
 * The {{PerformanceEntry/startTime}} attribute's getter must return a {{DOMHighResTimeStamp}} of when the paint occured.
 * The {{PerformanceEntry/duration}} attribute's getter must return 0.
 
-NOTE: A user agent implementing {{PerformancePaintTiming}} would need to include <code>"paint"</code> in {{PerformanceObserver/supportedEntryTypes}} for {{Window}} contexts.
-This allows developers to detect support for paint timing.
+Extension to {{PerformanceObserver/supportedEntryTypes}} {#sec-extendSupportedEntryTypesWithPaint}
+=======================================
+To allow developers to detect support for paint timing, the [=frozen array of supported entry types=] must include <code>"paint"</code> if any of the following apply: 
+* The [=relevant global object=] ia associated with a [=top level browsing context=]
+* The [=relevant global object=] is associated with a [=nested browsing context=], and the user-agent would run the [=mark paint timing=] algorithm for the [=document=] associated for that [=browsing context=].
 
 Processing model {#sec-processing-model}
 ========================================

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -21,7 +21,6 @@ urlPrefix: https://www.w3.org/TR/performance-timeline-2/; spec: PERFORMANCE-TIME
         text: startTime; url: #dom-performanceentry-starttime
         text: duration; url: #dom-performanceentry-duration
     type: dfn; url: #dfn-register-a-performance-entry-type; text: register a performance entry type
-    type: dfn; url: #dfn-frozen-array-of-supported-entry-types; text: frozen array of supported entry types;
     type: attribute; for: PerformanceObserver;
         text: supportedEntryTypes; url: #supportedentrytypes-attribute
 urlPrefix: https://www.w3.org/TR/hr-time-2/#idl-def-domhighrestimestamp; spec: HR-TIME-2;

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -200,7 +200,7 @@ Reporting paint timing {#sec-reporting-paint-timing}
 
 <div algorithm="Mark paint timing">
     When asked to [=mark paint timing=] given a [=Document=] |document| as input, perform the following steps:
-    1. If the [=document=]'s [=browsing context=] is not an [=paint-timing eligible=] [=browsing context=], return.
+    1. If the [=document=]'s [=browsing context=] is not a [=paint-timing eligible=] [=browsing context=], return.
     1. Let |paintTimestamp| be the [=current high resolution time=].
     1. If this instance of [=update the rendering=] is the [=first paint=] of |document|, then invoke the [[#report-paint-timing]] algorithm with |document|, <code>"first-paint"</code>, and |paintTimestamp|.
 


### PR DESCRIPTION
Edited the notes about `supportedEntryTypes` to clarify that they're specific to the frame/browsing-context


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/paint-timing/pull/79.html" title="Last updated on Mar 31, 2020, 5:21 PM UTC (47b0787)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/paint-timing/79/e891c87...47b0787.html" title="Last updated on Mar 31, 2020, 5:21 PM UTC (47b0787)">Diff</a>