### PR TITLE
Cover an edge-case with typographic pseudo elements

### DIFF
--- a/painttiming.bs
+++ b/painttiming.bs
@@ -54,6 +54,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage/dom.html
     type: dfn; text: represents; url: #represents;
 urlPrefix: https://drafts.csswg.org/css-pseudo-4
     type: dfn; text: generated content pseudo-element; url: #generated-content;
+    type: dfn; text: typographical pseudo-element; url: #typographic-pseudos;
 urlPrefix: https://www.w3.org/TR/cssom-view
     type: dfn; text: getBoundingClientRect; url: #dom-element-getboundingclientrect;
     type: dfn; text: scrolling area; url: #scrolling-area;
@@ -123,8 +124,12 @@ A [=CSS image=] |img| is a <dfn>contentful image</dfn> when all of the following
 
 A {{DOMString}} is <dfn>non-empty</dfn> if it contains at least one character excluding [=document white space characters=].
 
+A [=text node=] |n| is a <dfn>paintable text node</dfn> when any of the following apply:
+* |n| is not part of a [=typographical pseudo-element=].
+* |n| is part of a [=typographical pseudo-element=] |e|, and |e| is [=paintable=].
+
 An [=element=] |target| is <dfn export>contentful</dfn> when one or more of the following apply:
-* |target| has a [=text node=] child, representing [=non-empty=] text.
+* |target| has a [=paintable text node=] child, representing [=non-empty=] text.
 * |target| is a [=replaced element=] representing an [=available=] [=image=].
 * |target| has a [=background-image=] which is a [=contentful image=], and its [=used=] [=background-size=] has non-zero width and height values.
 * |target| is a [=canvas=] with its [=context mode=] set to any value other than <code>none</code>.

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -124,12 +124,11 @@ A [=CSS image=] |img| is a <dfn>contentful image</dfn> when all of the following
 
 A {{DOMString}} is <dfn>non-empty</dfn> if it contains at least one character excluding [=document white space characters=].
 
-A [=text node=] |n| is a <dfn>paintable text node</dfn> when any of the following apply:
-* |n| is not part of a [=typographical pseudo-element=].
-* |n| is part of a [=typographical pseudo-element=] |e|, and |e| is [=paintable=].
-
 An [=element=] |target| is <dfn export>contentful</dfn> when one or more of the following apply:
-* |target| has a [=paintable text node=] child, representing [=non-empty=] text.
+* |target| has a [=text node=] child, representing [=non-empty=] text, and the node's [=used=] [=opacity=] is greater than zero.
+
+    NOTE: this covers the case where a [=typographical pseudo-element=] would override the opacity of the text node.
+
 * |target| is a [=replaced element=] representing an [=available=] [=image=].
 * |target| has a [=background-image=] which is a [=contentful image=], and its [=used=] [=background-size=] has non-zero width and height values.
 * |target| is a [=canvas=] with its [=context mode=] set to any value other than <code>none</code>.


### PR DESCRIPTION
See https://github.com/w3c/paint-timing/issues/77

For now not mentioning `::selection` as it's an interaction-based pseudo-element.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/paint-timing/pull/80.html" title="Last updated on Mar 27, 2020, 2:41 PM UTC (1893861)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/paint-timing/80/2543599...1893861.html" title="Last updated on Mar 27, 2020, 2:41 PM UTC (1893861)">Diff</a>