### PR TITLE
Make first-paint optional

### DIFF
--- a/painttiming.bs
+++ b/painttiming.bs
@@ -203,7 +203,7 @@ Reporting paint timing {#sec-reporting-paint-timing}
     When asked to [=mark paint timing=] given a [=Document=] |document| as input, perform the following steps:
     1. If the [=document=]'s [=responsible browsing context=] is not [=paint-timing eligible=], return.
     1. Let |paintTimestamp| be the [=current high resolution time=].
-    1. If this instance of [=update the rendering=] is the [=first paint=] of |document|, and the user-agent is configured to report [=first paint=], then invoke the [[#report-paint-timing]] algorithm with |document|, <code>"first-paint"</code>, and |paintTimestamp|.
+    1. If this instance of [=update the rendering=] is the [=first paint=] of |document|, and the user-agent is configured to mark [=first paint=], then invoke the [[#report-paint-timing]] algorithm with |document|, <code>"first-paint"</code>, and |paintTimestamp|.
 
         NOTE: [=First paint=] excludes the default background paint, but includes non-default background paint.
 

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -203,7 +203,7 @@ Reporting paint timing {#sec-reporting-paint-timing}
     When asked to [=mark paint timing=] given a [=Document=] |document| as input, perform the following steps:
     1. If the [=document=]'s [=responsible browsing context=] is not [=paint-timing eligible=], return.
     1. Let |paintTimestamp| be the [=current high resolution time=].
-    1. If this instance of [=update the rendering=] is the [=first paint=] of |document|, and the user-agent is configured to mark [=first paint=], then invoke the [[#report-paint-timing]] algorithm with |document|, <code>"first-paint"</code>, and |paintTimestamp|.
+    1. If this instance of [=update the rendering=] is the [=first paint=] of |document|, and the user agent is configured to mark [=first paint=], then invoke the [[#report-paint-timing]] algorithm with |document|, <code>"first-paint"</code>, and |paintTimestamp|.
 
         NOTE: [=First paint=] excludes the default background paint, but includes non-default background paint.
 

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -168,8 +168,8 @@ A [=browsing context=] |ctx| is <dfn>paint-timing eligible</dfn> when one of the
 * |ctx| is a [=top-level browsing context=].
 * |ctx| is a [=nested browsing context=], and the user agent has configured |ctx| to report paint timing.
 
-    NOTE: this allows user-agents to enable paint-timing only for some of the frames, in addition to the main frame, if they so choose.
-    For example, a user-agent may decide to disable paint-timing for cross-origin iframes, as in some scenarios their paint-timing might reveal information about the main frame.
+    NOTE: this allows user agents to enable paint-timing only for some of the frames, in addition to the main frame, if they so choose.
+    For example, a user agent may decide to disable paint-timing for cross-origin iframes, as in some scenarios their paint-timing might reveal information about the main frame.
 
 The {{PerformancePaintTiming}} interface {#sec-PerformancePaintTiming}
 =======================================

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -203,7 +203,7 @@ Reporting paint timing {#sec-reporting-paint-timing}
     When asked to [=mark paint timing=] given a [=Document=] |document| as input, perform the following steps:
     1. If the [=document=]'s [=responsible browsing context=] is not [=paint-timing eligible=], return.
     1. Let |paintTimestamp| be the [=current high resolution time=].
-    1. If this instance of [=update the rendering=] is the [=first paint=] of |document|, then invoke the [[#report-paint-timing]] algorithm with |document|, <code>"first-paint"</code>, and |paintTimestamp|.
+    1. If this instance of [=update the rendering=] is the [=first paint=] of |document|, and the user-agent is configured to report [=first paint=], then invoke the [[#report-paint-timing]] algorithm with |document|, <code>"first-paint"</code>, and |paintTimestamp|.
 
         NOTE: [=First paint=] excludes the default background paint, but includes non-default background paint.
 
@@ -212,6 +212,9 @@ Reporting paint timing {#sec-reporting-paint-timing}
         NOTE: A parent frame should not be aware of the paint events from its child iframes, and vice versa. This means that a frame that contains just iframes will have [=first paint=] (due to the enclosing boxes of the iframes) but no [=first contentful paint=].
 
         NOTE: A [=document=] is not guaranteed to mark [=first paint=] [=first contentful paint=]. A completely blank [=document=] may never mark [=first paint=], and a [=document=] containing only elements that are not [=contentful=], may never mark [=first contentful paint=].
+
+    NOTE: The marking of [=first paint=] is optional. User-agents implementing paint timing should at the very least mark [=first contentful paint=] .
+
 </div>
 
 <h4 dfn>Report paint timing</h4>


### PR DESCRIPTION
How is this @npm1 @yoavweiss?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/paint-timing/pull/81.html" title="Last updated on Apr 1, 2020, 6:54 PM UTC (2eeedbb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/paint-timing/81/e85cc0a...2eeedbb.html" title="Last updated on Apr 1, 2020, 6:54 PM UTC (2eeedbb)">Diff</a>