### PR TITLE
Be explicit about marking each paint type only once

### DIFF
--- a/painttiming.bs
+++ b/painttiming.bs
@@ -166,8 +166,6 @@ An [=element=] |el| is <dfn>paintable</dfn> when all of the following apply:
 
 <dfn export>First paint</dfn> entry contains a {{DOMHighResTimeStamp}} reporting the time when the user agent first rendered after navigation. This excludes the default background paint, but includes non-default background paint and the enclosing box of an iframe. This is the first key moment developers care about in page load – when the user agent has started to render the page.
 
-<dfn export>First contentful paint</dfn> entry contains a {{DOMHighResTimeStamp}} reporting the time when the user agent first rendered a [=document=] which includes at least one [=element=] that is both [=contentful=] and [=paintable=].
-
 A [=browsing context=] |ctx| is <dfn>paint-timing eligible</dfn> when one of the following apply:
 * |ctx| is a [=top-level browsing context=].
 * |ctx| is a [=nested browsing context=], and the user agent has configured |ctx| to report paint timing.
@@ -204,6 +202,14 @@ Reporting paint timing {#sec-reporting-paint-timing}
 <h4 dfn>Previously reported paints</h4>
 Every [=Document=] has an associated [=set=] of previously reported paints, initiallized to an empty [=set=].
 
+<h4 dfn export>First Contentful Paint</h4>
+<div algorithm="Compute first contentful paint">
+    When asked to compute [=first contentful paint=] given |document|, perform the following steps:
+    1. If |document|'s [=previously reported paints=] contains <code>"first-contentful-paint"</code>, then return false.
+    1. If |document| contains at least one [=element=] that is both [=paintable=] and [=contentful=], then return true.
+    1. Otherwise, return false.
+</div>
+
 <h4 dfn export>Mark paint timing</h4>
 
 <div algorithm="Mark paint timing">
@@ -211,22 +217,20 @@ Every [=Document=] has an associated [=set=] of previously reported paints, init
     1. If the [=document=]'s [=responsible browsing context=] is not [=paint-timing eligible=], return.
     1. Let |paintTimestamp| be the [=current high resolution time=].
     1. Let |reportedPaints| be the [=previously reported paints=] associated with |document|.
-    1. If this instance of [=update the rendering=] is the [=first paint=] of |document|, and |reportedPaints| does not contain <code>"first-paint"</code>, then:
-        1. invoke the [[#report-paint-timing]] algorithm with |document|, <code>"first-paint"</code>, and |paintTimestamp|.
+    1. If |reportedPaints| does not contain <code>"first-paint"</code>, then:
+        1. Invoke the [[#report-paint-timing]] algorithm with |document|, <code>"first-paint"</code>, and |paintTimestamp|.
 
             NOTE: [=First paint=] excludes the default background paint, but includes non-default background paint.
 
         1. [=Append=] <code>"first-paint"</code> to |reportedPaints|.
 
-    1. If this instance of [=update the rendering=] is the [=first contentful paint=] of |document|, and |reportedPaints| does not contain <code>"first-contentful-paint"</code>, then:
-        1. invoke the [[#report-paint-timing]] algorithm with |document|, <code>"first-contentful-paint"</code>, and |paintTimestamp| as arguments.
+    1. If the result of invoking the [-compute first contentful paint=] with |document| returns <code>true</code>, then:
+        1. Invoke the [[#report-paint-timing]] algorithm with |document|, <code>"first-contentful-paint"</code>, and |paintTimestamp| as arguments.
         1. [=Append=] <code>"first-contentful-paint"</code> to |reportedPaints|.
 
         NOTE: A parent frame should not be aware of the paint events from its child iframes, and vice versa. This means that a frame that contains just iframes will have [=first paint=] (due to the enclosing boxes of the iframes) but no [=first contentful paint=].
 
-        NOTE: A [=document=] is not guaranteed to mark [=first paint=] [=first contentful paint=]. A completely blank [=document=] may never mark [=first paint=], and a [=document=] containing only elements that are not [=contentful=], may never mark [=first contentful paint=].
-
-
+        NOTE: A [=document=] is not guaranteed to mark <code>"first-paint"</code> or <code>"first-contentful-paint"</code>. A completely blank [=document=] may never mark [=first paint=], and a [=document=] containing only elements that are not [=contentful=], may never mark [=first contentful paint=].
 </div>
 
 <h4 dfn>Report paint timing</h4>

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -199,12 +199,11 @@ Processing model {#sec-processing-model}
 Reporting paint timing {#sec-reporting-paint-timing}
 --------------------------------------------------------
 
-<h4 dfn>Previously reported paints</h4>
-Every [=Document=] has an associated [=set=] of previously reported paints, initiallized to an empty [=set=].
+Every [=Document=] has an associated [=set=] of <dfn>previously reported paints</dfn>, initiallized to an empty [=set=].
 
 <h4 dfn export>First Contentful Paint</h4>
-<div algorithm="Compute first contentful paint">
-    When asked to <dfn>compute first contentful paint</dfn> given |document|, perform the following steps:
+<div algorithm="Should report first contentful paint">
+    To know whether [=Document=] |document| <dfn>should report first contentful paint</dfn>, perform the following steps:
     1. If |document|'s [=previously reported paints=] contains <code>"first-contentful-paint"</code>, then return false.
     1. If |document| contains at least one [=element=] that is both [=paintable=] and [=contentful=], then return true.
     1. Otherwise, return false.
@@ -222,11 +221,8 @@ Every [=Document=] has an associated [=set=] of previously reported paints, init
 
             NOTE: [=First paint=] excludes the default background paint, but includes non-default background paint.
 
-        1. [=Append=] <code>"first-paint"</code> to |reportedPaints|.
-
-    1. If the result of invoking the [=compute first contentful paint=] with |document| returns <code>true</code>, then:
+    1. If |document| [=should report first contentful paint=], then:
         1. Invoke the [[#report-paint-timing]] algorithm with |document|, <code>"first-contentful-paint"</code>, and |paintTimestamp| as arguments.
-        1. [=Append=] <code>"first-contentful-paint"</code> to |reportedPaints|.
 
         NOTE: A parent frame should not be aware of the paint events from its child iframes, and vice versa. This means that a frame that contains just iframes will have [=first paint=] (due to the enclosing boxes of the iframes) but no [=first contentful paint=].
 

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -202,7 +202,7 @@ Reporting paint timing {#sec-reporting-paint-timing}
 --------------------------------------------------------
 
 <h4 dfn>Previously reported paints</h4>
-Every [=document=] has an associated [=set=] of previously reported paints, initiallized to an empty list.
+Every [=Document=] has an associated [=set=] of previously reported paints, initiallized to an empty [=set=].
 
 <h4 dfn export>Mark paint timing</h4>
 
@@ -210,11 +210,12 @@ Every [=document=] has an associated [=set=] of previously reported paints, init
     When asked to [=mark paint timing=] given a [=Document=] |document| as input, perform the following steps:
     1. If the [=document=]'s [=responsible browsing context=] is not [=paint-timing eligible=], return.
     1. Let |paintTimestamp| be the [=current high resolution time=].
-    1. If this instance of [=update the rendering=] is the [=first paint=] of |document|, then invoke the [[#report-paint-timing]] algorithm with |document|, <code>"first-paint"</code>, and |paintTimestamp|.
+    1. Let |reportedPaints| be the [=previously reported paints=] associated with |document|.
+    1. If this instance of [=update the rendering=] is the [=first paint=] of |document|, and |reportedPaints| does not contain <code>"first-paint"</code>, then invoke the [[#report-paint-timing]] algorithm with |document|, <code>"first-paint"</code>, and |paintTimestamp|.
 
         NOTE: [=First paint=] excludes the default background paint, but includes non-default background paint.
 
-    1. If this instance of [=update the rendering=] is the [=first contentful paint=] of |document|, then invoke the [[#report-paint-timing]] algorithm with |document|, <code>"first-contentful-paint"</code>, and |paintTimestamp| as arguments.
+    1. If this instance of [=update the rendering=] is the [=first contentful paint=] of |document|, and |reportedPaints| does not contain <code>"first-contentful-paint"</code>, then invoke the [[#report-paint-timing]] algorithm with |document|, <code>"first-contentful-paint"</code>, and |paintTimestamp| as arguments.
 
         NOTE: A parent frame should not be aware of the paint events from its child iframes, and vice versa. This means that a frame that contains just iframes will have [=first paint=] (due to the enclosing boxes of the iframes) but no [=first contentful paint=].
 
@@ -225,15 +226,13 @@ Every [=document=] has an associated [=set=] of previously reported paints, init
 
 <div algorithm="Report paint timing">
     When asked to [=report paint timing=] given |document|, |paintType|, and |paintTimestamp| as arguments, perform the following steps:
-    1. Let |reportedPaints| be |document|'s associated [=previously reported paints=].
-    1. If |reportedPaints| [=contains=] |paintType|, return.
     1. Create a <a spec=webidl>new</a> {{PerformancePaintTiming}} object |newEntry| with |document|'s [=relevant realm=] and set its attributes as follows:
         1. Set |newEntry|'s {{PerformanceEntry/name}} attribute to |paintType|.
         1. Set |newEntry|'s {{PerformanceEntry/entryType}} attribute to <code>"paint"</code>.
         1. Set |newEntry|'s {{PerformanceEntry/startTime}} attribute to |paintTimestamp|.
         1. Set |newEntry|'s {{PerformanceEntry/duration}} attribute to 0.
     1. <a href="https://w3c.github.io/performance-timeline/#dfn-queue-a-performanceentry">Add the PerformanceEntry</a> |newEntry| object.
-    1. [=Append=] |paintType| to |reportedPaints|.
+    1. [=Append=] |paintType| to |document|'s associated [=previously reported paints=].
 </div>
 
 

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -204,7 +204,7 @@ Every [=Document=] has an associated [=set=] of previously reported paints, init
 
 <h4 dfn export>First Contentful Paint</h4>
 <div algorithm="Compute first contentful paint">
-    When asked to compute [=first contentful paint=] given |document|, perform the following steps:
+    When asked to <dfn>compute first contentful paint</dfn> given |document|, perform the following steps:
     1. If |document|'s [=previously reported paints=] contains <code>"first-contentful-paint"</code>, then return false.
     1. If |document| contains at least one [=element=] that is both [=paintable=] and [=contentful=], then return true.
     1. Otherwise, return false.
@@ -224,7 +224,7 @@ Every [=Document=] has an associated [=set=] of previously reported paints, init
 
         1. [=Append=] <code>"first-paint"</code> to |reportedPaints|.
 
-    1. If the result of invoking the [-compute first contentful paint=] with |document| returns <code>true</code>, then:
+    1. If the result of invoking the [=compute first contentful paint=] with |document| returns <code>true</code>, then:
         1. Invoke the [[#report-paint-timing]] algorithm with |document|, <code>"first-contentful-paint"</code>, and |paintTimestamp| as arguments.
         1. [=Append=] <code>"first-contentful-paint"</code> to |reportedPaints|.
 

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -217,13 +217,17 @@ Reporting paint timing {#sec-reporting-paint-timing}
 <h4 dfn>Report paint timing</h4>
 
 <div algorithm="Report paint timing">
+    Each [=document=] has an associated array of previously reported paint types. Let that array be |reportedPaints|.
+
     When asked to [=report paint timing=] given |document|, |paintType|, and |paintTimestamp| as arguments, perform the following steps:
+    1. If |reportedPaints| associated with |document| includes |paintType|, return.
     1. Create a <a spec=webidl>new</a> {{PerformancePaintTiming}} object |newEntry| with |document|'s [=relevant realm=] and set its attributes as follows:
         1. Set |newEntry|'s {{PerformanceEntry/name}} attribute to |paintType|.
         1. Set |newEntry|'s {{PerformanceEntry/entryType}} attribute to <code>"paint"</code>.
         1. Set |newEntry|'s {{PerformanceEntry/startTime}} attribute to |paintTimestamp|.
         1. Set |newEntry|'s {{PerformanceEntry/duration}} attribute to 0.
     1. <a href="https://w3c.github.io/performance-timeline/#dfn-queue-a-performanceentry">Add the PerformanceEntry</a> |newEntry| object.
+    1. Append |paintType| to |reportedPaints| associated with |document|.
 </div>
 
 

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -220,7 +220,7 @@ Every [=Document=] has an associated [=set=] of <dfn>previously reported paints<
 
         NOTE: [=First paint=] excludes the default background paint, but includes non-default background paint.
 
-        ISSUE: This should be turned into a normative note.
+            ISSUE: This should be turned into a normative note.
 
     1. If |document| [=should report first contentful paint=], then:
         1. Invoke the [[#report-paint-timing]] algorithm with |document|, <code>"first-contentful-paint"</code>, and |paintTimestamp| as arguments.

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -202,7 +202,7 @@ Reporting paint timing {#sec-reporting-paint-timing}
 --------------------------------------------------------
 
 <h4 dfn>Previously reported paints</h4>
-Every [=document=] has an associated [=set=] of previously reported paints, initiallized to be an empty list.
+Every [=document=] has an associated [=set=] of previously reported paints, initiallized to an empty list.
 
 <h4 dfn export>Mark paint timing</h4>
 

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -201,6 +201,9 @@ Processing model {#sec-processing-model}
 Reporting paint timing {#sec-reporting-paint-timing}
 --------------------------------------------------------
 
+<h4 dfn>Previously reported paints</h4>
+Every [=document=] has an associated [=set=] of previously reported paints, initiallized to be an empty list.
+
 <h4 dfn export>Mark paint timing</h4>
 
 <div algorithm="Mark paint timing">
@@ -218,20 +221,20 @@ Reporting paint timing {#sec-reporting-paint-timing}
         NOTE: A [=document=] is not guaranteed to mark [=first paint=] [=first contentful paint=]. A completely blank [=document=] may never mark [=first paint=], and a [=document=] containing only elements that are not [=contentful=], may never mark [=first contentful paint=].
 </div>
 
-<h4 dfn>Report paint timing</h4>
+<h4 dfn export>Report paint timing</h4>
 
 <div algorithm="Report paint timing">
-    Each [=document=] has an associated [=set=] of previously reported paint types. Let that array be |reportedPaints|.
-
     When asked to [=report paint timing=] given |document|, |paintType|, and |paintTimestamp| as arguments, perform the following steps:
-    1. If |reportedPaints| associated with |document| [=contains=] |paintType|, return.
+
+    1. Let |reportedPaints| be |document|'s associated [=previously reported paints=].
+    1. If |reportedPaints| [=contains=] |paintType|, return.
     1. Create a <a spec=webidl>new</a> {{PerformancePaintTiming}} object |newEntry| with |document|'s [=relevant realm=] and set its attributes as follows:
         1. Set |newEntry|'s {{PerformanceEntry/name}} attribute to |paintType|.
         1. Set |newEntry|'s {{PerformanceEntry/entryType}} attribute to <code>"paint"</code>.
         1. Set |newEntry|'s {{PerformanceEntry/startTime}} attribute to |paintTimestamp|.
         1. Set |newEntry|'s {{PerformanceEntry/duration}} attribute to 0.
     1. <a href="https://w3c.github.io/performance-timeline/#dfn-queue-a-performanceentry">Add the PerformanceEntry</a> |newEntry| object.
-    1. [=Append=] |paintType| to |reportedPaints| associated with |document|.
+    1. [=Append=] |paintType| to |reportedPaints|.
 </div>
 
 

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -216,12 +216,11 @@ Every [=Document=] has an associated [=set=] of <dfn>previously reported paints<
     1. If the [=document=]'s [=responsible browsing context=] is not [=paint-timing eligible=], return.
     1. Let |paintTimestamp| be the [=current high resolution time=].
     1. Let |reportedPaints| be the [=previously reported paints=] associated with |document|.
-    1. If |reportedPaints| does not contain <code>"first-paint"</code>, then:
-        1. If the user agent is configured to mark [=first paint=], then invoke the [[#report-paint-timing]] algorithm with |document|, <code>"first-paint"</code>, and |paintTimestamp|.
+    1. If |reportedPaints| does not contain <code>"first-paint"</code>, and the user agent is configured to mark [=first paint=], then invoke the [[#report-paint-timing]] algorithm with |document|, <code>"first-paint"</code>, and |paintTimestamp|.
 
-            NOTE: [=First paint=] excludes the default background paint, but includes non-default background paint.
+        NOTE: [=First paint=] excludes the default background paint, but includes non-default background paint.
 
-            ISSUE: This should be turned into a normative note.
+        ISSUE: This should be turned into a normative note.
 
     1. If |document| [=should report first contentful paint=], then:
         1. Invoke the [[#report-paint-timing]] algorithm with |document|, <code>"first-contentful-paint"</code>, and |paintTimestamp| as arguments.

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -76,6 +76,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage/webappapis.html
 urlPrefix: https://infra.spec.whatwg.org/
     type: dfn; text: set; url: #sets;
     type: dfn; text: contains; url: #list-contain;
+    type: dfn; text: append; url: #list-append;
 </pre>
 
 Introduction {#intro}
@@ -230,7 +231,7 @@ Reporting paint timing {#sec-reporting-paint-timing}
         1. Set |newEntry|'s {{PerformanceEntry/startTime}} attribute to |paintTimestamp|.
         1. Set |newEntry|'s {{PerformanceEntry/duration}} attribute to 0.
     1. <a href="https://w3c.github.io/performance-timeline/#dfn-queue-a-performanceentry">Add the PerformanceEntry</a> |newEntry| object.
-    1. Append |paintType| to |reportedPaints| associated with |document|.
+    1. [=Append=] |paintType| to |reportedPaints| associated with |document|.
 </div>
 
 

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -73,6 +73,9 @@ urlPrefix: https://html.spec.whatwg.org/multipage/browsers.html
     type: dfn; text: nested browsing context; url: #nested-browsing-context;
 urlPrefix: https://html.spec.whatwg.org/multipage/webappapis.html
     type: dfn; text: global object; url: #concept-realm-global;
+urlPrefix: https://infra.spec.whatwg.org/
+    type: dfn; text: set; url: #sets;
+    type: dfn; text: contains; url: #list-contain;
 </pre>
 
 Introduction {#intro}
@@ -217,10 +220,10 @@ Reporting paint timing {#sec-reporting-paint-timing}
 <h4 dfn>Report paint timing</h4>
 
 <div algorithm="Report paint timing">
-    Each [=document=] has an associated array of previously reported paint types. Let that array be |reportedPaints|.
+    Each [=document=] has an associated [=set=] of previously reported paint types. Let that array be |reportedPaints|.
 
     When asked to [=report paint timing=] given |document|, |paintType|, and |paintTimestamp| as arguments, perform the following steps:
-    1. If |reportedPaints| associated with |document| includes |paintType|, return.
+    1. If |reportedPaints| associated with |document| [=contains=] |paintType|, return.
     1. Create a <a spec=webidl>new</a> {{PerformancePaintTiming}} object |newEntry| with |document|'s [=relevant realm=] and set its attributes as follows:
         1. Set |newEntry|'s {{PerformanceEntry/name}} attribute to |paintType|.
         1. Set |newEntry|'s {{PerformanceEntry/entryType}} attribute to <code>"paint"</code>.

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -221,11 +221,10 @@ Every [=document=] has an associated [=set=] of previously reported paints, init
         NOTE: A [=document=] is not guaranteed to mark [=first paint=] [=first contentful paint=]. A completely blank [=document=] may never mark [=first paint=], and a [=document=] containing only elements that are not [=contentful=], may never mark [=first contentful paint=].
 </div>
 
-<h4 dfn export>Report paint timing</h4>
+<h4 dfn>Report paint timing</h4>
 
 <div algorithm="Report paint timing">
     When asked to [=report paint timing=] given |document|, |paintType|, and |paintTimestamp| as arguments, perform the following steps:
-
     1. Let |reportedPaints| be |document|'s associated [=previously reported paints=].
     1. If |reportedPaints| [=contains=] |paintType|, return.
     1. Create a <a spec=webidl>new</a> {{PerformancePaintTiming}} object |newEntry| with |document|'s [=relevant realm=] and set its attributes as follows:

--- a/painttiming.bs
+++ b/painttiming.bs
@@ -211,15 +211,22 @@ Every [=Document=] has an associated [=set=] of previously reported paints, init
     1. If the [=document=]'s [=responsible browsing context=] is not [=paint-timing eligible=], return.
     1. Let |paintTimestamp| be the [=current high resolution time=].
     1. Let |reportedPaints| be the [=previously reported paints=] associated with |document|.
-    1. If this instance of [=update the rendering=] is the [=first paint=] of |document|, and |reportedPaints| does not contain <code>"first-paint"</code>, then invoke the [[#report-paint-timing]] algorithm with |document|, <code>"first-paint"</code>, and |paintTimestamp|.
+    1. If this instance of [=update the rendering=] is the [=first paint=] of |document|, and |reportedPaints| does not contain <code>"first-paint"</code>, then:
+        1. invoke the [[#report-paint-timing]] algorithm with |document|, <code>"first-paint"</code>, and |paintTimestamp|.
 
-        NOTE: [=First paint=] excludes the default background paint, but includes non-default background paint.
+            NOTE: [=First paint=] excludes the default background paint, but includes non-default background paint.
 
-    1. If this instance of [=update the rendering=] is the [=first contentful paint=] of |document|, and |reportedPaints| does not contain <code>"first-contentful-paint"</code>, then invoke the [[#report-paint-timing]] algorithm with |document|, <code>"first-contentful-paint"</code>, and |paintTimestamp| as arguments.
+        1. [=Append=] <code>"first-paint"</code> to |reportedPaints|.
+
+    1. If this instance of [=update the rendering=] is the [=first contentful paint=] of |document|, and |reportedPaints| does not contain <code>"first-contentful-paint"</code>, then:
+        1. invoke the [[#report-paint-timing]] algorithm with |document|, <code>"first-contentful-paint"</code>, and |paintTimestamp| as arguments.
+        1. [=Append=] <code>"first-contentful-paint"</code> to |reportedPaints|.
 
         NOTE: A parent frame should not be aware of the paint events from its child iframes, and vice versa. This means that a frame that contains just iframes will have [=first paint=] (due to the enclosing boxes of the iframes) but no [=first contentful paint=].
 
         NOTE: A [=document=] is not guaranteed to mark [=first paint=] [=first contentful paint=]. A completely blank [=document=] may never mark [=first paint=], and a [=document=] containing only elements that are not [=contentful=], may never mark [=first contentful paint=].
+
+
 </div>
 
 <h4 dfn>Report paint timing</h4>


### PR DESCRIPTION
Should resolve https://github.com/w3c/paint-timing/issues/38


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/paint-timing/pull/82.html" title="Last updated on Apr 1, 2020, 7:21 PM UTC (078ee75)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/paint-timing/82/6b0033c...078ee75.html" title="Last updated on Apr 1, 2020, 7:21 PM UTC (078ee75)">Diff</a>