### PR TITLE
Chore: Add w3cids to editors

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6,9 +6,9 @@ Level: 1
 ED: https://w3c.github.io/paint-timing/
 TR: https://www.w3.org/TR/paint-timing/
 Status: WD
-Editor: Nicolás Peña Moreno, Google https://google.com, npm@chromium.org
-        Noam Rosenthal, Invited Expert, noam@webkit.org
-Former Editor: Shubhie Panicker, Google https://google.com, panicker@google.com
+Editor: Nicolás Peña Moreno, Google https://google.com, npm@chromium.org, w3cid 103755
+        Noam Rosenthal, Invited Expert, noam@webkit.org, w3cid 121539
+Former Editor: Shubhie Panicker, Google https://google.com, panicker@google.com, w3cid 92587
 Repository: w3c/paint-timing
 Abstract: This document defines an API that can be used to capture a series of key moments (first paint, first contentful paint) during pageload which developers care about.
 Default Highlight: js


### PR DESCRIPTION
Fixes https://github.com/w3c/paint-timing/runs/2955534035?check_suite_focus=true

Blocked on a new deployment of bikeshed to merge https://github.com/tabatkins/bikeshed/pull/2097