### PR TITLE
chore: Added workflow_dispatch to GitHub action

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -1,6 +1,7 @@
 name: CI
 on:
   pull_request: {}
+  workflow_dispatch: {}
   push:
     branches: [main]
 jobs:


### PR DESCRIPTION
This allows to run the GitHub action on demand rather than forcing a commit.