### PR TITLE
Update .pr-preview.json

### DIFF
--- a/.pr-preview.json
+++ b/.pr-preview.json
@@ -1,4 +1,4 @@
 {
-    "src_file": "painttiming.bs",
+    "src_file": "index.bs",
     "type": "bikeshed"
 }


### PR DESCRIPTION
Spec filename has changed in the last 4 years, updating to reference `index.bs` now.