### PR TITLE
Fix broken Long Animation Frames spec url

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -62,7 +62,7 @@ urlPrefix: https://wicg.github.io/largest-contentful-paint/; spec: ELEMENT-TIMIN
     type: dfn; url:#report-largest-contentful-paint; text: Report largest contentful paint
 urlPrefix: https://wicg.github.io/element-timing/; spec: ELEMENT-TIMING
     type: dfn; url:#report-element-timing; text: Report element timing
-urlPrefix: https://w3c.github.io/long-animation-frame/; spec: LONG-ANIMATION-FRAME
+urlPrefix: https://w3c.github.io/long-animation-frames/; spec: LONG-ANIMATION-FRAME
     type: dfn; url:#queue-a-long-animation-frame-entry; text: Queue a long animation frame entry
     type: dfn; text: current frame timing info
 </pre>


### PR DESCRIPTION
This fixes two broken links to the "Long Animation Frames" spec. I noticed them while reading, it appears that it's because of a missing `s` at the end.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/canova/paint-timing/pull/110.html" title="Last updated on Feb 23, 2025, 11:10 PM UTC (ba1b092)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/paint-timing/110/b5204cf...canova:ba1b092.html" title="Last updated on Feb 23, 2025, 11:10 PM UTC (ba1b092)">Diff</a>