### PR TITLE
Fix PaintTimingMixin section header and link

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -192,6 +192,8 @@ A [=browsing context=] |ctx| is <dfn>paint-timing eligible</dfn> when one of the
     For example, a user agent may decide to disable paint-timing for cross-origin iframes, as in some scenarios their paint-timing might reveal information about the main frame.
 
 The {{PaintTimingMixin}} interface {#sec-PaintTimingMixin}
+=======================================
+
 <pre class="idl">
     [Exposed=Window]
     interface mixin PaintTimingMixin {


### PR DESCRIPTION
Another minor thing I noticed. It looks like we wanted to have a section for `PaintTimingMixin`, but forgot to make it.

Before:
<img width="891" alt="Screenshot 2025-02-24 at 2 36 25 PM" src="https://github.com/user-attachments/assets/2ff8f51d-ba73-46a0-8ddf-d60757a077a7" />

After:
<img width="905" alt="Screenshot 2025-02-24 at 2 36 07 PM" src="https://github.com/user-attachments/assets/44568d35-51cd-4ea9-a2cb-2f898fe69f53" />


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/canova/paint-timing/pull/111.html" title="Last updated on Feb 24, 2025, 1:38 PM UTC (9d4ae1e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/paint-timing/111/b5204cf...canova:9d4ae1e.html" title="Last updated on Feb 24, 2025, 1:38 PM UTC (9d4ae1e)">Diff</a>